### PR TITLE
Fix build failure on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CXX=clang++
 # suppress all warnings :-(
-CXXFLAGS=-std=c++11 -stdlib=libc++ -Iapi -w
+CXXFLAGS=-std=c++11 -Iapi -w
 TARGET=pict
 all:
 	$(CXX) $(CXXFLAGS) api/*cpp cli/*cpp -o $(TARGET)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The test script produces a log: **dbg.log** or **rel.log** for the Debug and Rel
 
 ##Building with clang++ on Linux, OS/X, *BSD, etc
 Install clang through your package manager (most systems), Xcode (OS/X), or from the [LLVM website](http://llvm.org/releases/).
+On Linux, you also need to install recent libstdc++ offered by gcc 5.
 
 Run `make` to build the `pict` binary.
 

--- a/api/combination.cpp
+++ b/api/combination.cpp
@@ -1,4 +1,5 @@
 #include "generator.h"
+#include <cstring>
 
 namespace pictcore
 {

--- a/cli/pict.cpp
+++ b/cli/pict.cpp
@@ -4,6 +4,7 @@
 #endif
 
 #include <ctime>
+#include <cstring>
 using namespace std;
 
 #include "cmdline.h"

--- a/doc/pict.md
+++ b/doc/pict.md
@@ -370,7 +370,7 @@ When seeding is used, you will be warned if any of those problems exist in your 
     Clause        :: =
       Term
     | ( Predicate )
-    | NOT Compound
+    | NOT Predicate
 
     Term          :: =
       ParameterName Relation Value


### PR DESCRIPTION
Fixed build failure of PICT on Linux.

Some headers include was missing and Makefile did not support Linux environment actually.
I fixed them and now PICT can be built on Windows, OS/X and Linux successfully.

I also fixed wrong Constraints Grammar in pict.md. I'll make another pull request for it if it's better.
