### PR TITLE
GNU/Linux build improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CXX=clang++
 # suppress all warnings :-(
-CXXFLAGS=-std=c++11 -Iapi -w
+CXXFLAGS=-std=c++11 -Iapi -w -fpermissive
 TARGET=pict
 TEST_OUTPUT = test/rel.log test/rel.log.failures test/dbg.log
 TEST_OUTPUT += test/.stdout test/.stderr

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-CXX=clang++
+# To use another compiler, such clang++, set the CXX variable
+# CXX=clang++
 # suppress all warnings :-(
 CXXFLAGS=-std=c++11 -Iapi -w -fpermissive
 TARGET=pict

--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,22 @@ CXXFLAGS=-std=c++11 -Iapi -w
 TARGET=pict
 TEST_OUTPUT = test/rel.log test/rel.log.failures test/dbg.log
 TEST_OUTPUT += test/.stdout test/.stderr
+OBJS = api/combination.o api/deriver.o api/exclusion.o
+OBJS += api/model.o api/parameter.o api/pictapi.o
+OBJS += api/task.o api/worklist.o cli/ccommon.o cli/cmdline.o
+OBJS += cli/common.o cli/cparser.o cli/ctokenizer.o cli/gcd.o
+OBJS += cli/gcdexcl.o cli/gcdmodel.o cli/model.o cli/mparser.o
+OBJS += cli/pict.o cli/strings.o
 
-all:
-	$(CXX) $(CXXFLAGS) api/*cpp cli/*cpp -o $(TARGET)
+pict: $(OBJS)
+	$(CXX) $(OBJS) -o $(TARGET)
 
 test:
 	cd test; perl test.pl ../$(TARGET) rel.log
 
 clean:
-	rm -f $(TARGET) $(TEST_OUTPUT)
+	rm -f $(TARGET) $(TEST_OUTPUT) $(OBJS)
+
+all: pict
 
 .PHONY: all test clean

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 # To use another compiler, such clang++, set the CXX variable
 # CXX=clang++
+# variables used to generate a source snapshot of the GIT repo
+COMMIT=$(shell git log --pretty=format:'%H' -n 1)
+SHORT_COMMIT=$(shell git log --pretty=format:'%h' -n 1)
 # suppress all warnings :-(
 CXXFLAGS=-std=c++11 -Iapi -w -fpermissive
 TARGET=pict
@@ -23,4 +26,7 @@ clean:
 
 all: pict
 
-.PHONY: all test clean
+source: clean
+	git archive --prefix="pict-$(COMMIT)/" -o "pict-$(SHORT_COMMIT).tar.gz" $(COMMIT)
+
+.PHONY: all test clean source

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,16 @@ CXX=clang++
 # suppress all warnings :-(
 CXXFLAGS=-std=c++11 -Iapi -w
 TARGET=pict
+TEST_OUTPUT = test/rel.log test/rel.log.failures test/dbg.log
+TEST_OUTPUT += test/.stdout test/.stderr
+
 all:
 	$(CXX) $(CXXFLAGS) api/*cpp cli/*cpp -o $(TARGET)
 
 test:
 	cd test; perl test.pl ../$(TARGET) rel.log
 
-.PHONY: all test
+clean:
+	rm -f $(TARGET) $(TEST_OUTPUT)
+
+.PHONY: all test clean

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ OBJS += cli/pict.o cli/strings.o
 pict: $(OBJS)
 	$(CXX) $(OBJS) -o $(TARGET)
 
-test:
+test: $(TARGET)
 	cd test; perl test.pl ../$(TARGET) rel.log
 
 clean:

--- a/api/pictapi.h
+++ b/api/pictapi.h
@@ -13,7 +13,11 @@
 #define OPT
 #endif
 
+#if defined( __GNUC__ )
+#define API_SPEC
+#else
 #define API_SPEC __stdcall
+#endif
 
 #if defined( __cplusplus )
 extern "C" {


### PR DESCRIPTION
This is a collection of build related improvements.  In a nutshell, it allows for parallel (and cached when using ccache) builds.  It also improves compiler support, allowing systems with only GCC (g++) to build pict.

It serves as the foundation for two other PR currently being worked on:
 * RPM Packaging support
 * Build with all warnings enabled, and errors treated as warnings (`-Wall -Werror`).