### PR TITLE
cli/pict.cpp: fix a typo on the `__cdecl` definition

### DIFF
--- a/cli/pict.cpp
+++ b/cli/pict.cpp
@@ -37,7 +37,7 @@ void printTimeDifference( time_t start, time_t end )
 //
 //
 //
-int _cdecl execute
+int __cdecl execute
     (
     IN     int      argc,
     IN     wchar_t* args[],


### PR DESCRIPTION
Signed-off-by: Cleber Rosa <crosa@redhat.com>