### PR TITLE
Fix Makefile to support building shared library for Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,27 +4,33 @@
 COMMIT=$(shell git log --pretty=format:'%H' -n 1)
 SHORT_COMMIT=$(shell git log --pretty=format:'%h' -n 1)
 # suppress all warnings :-(
-CXXFLAGS=-std=c++11 -Iapi -w -fpermissive
+CXXFLAGS=-fPIC -std=c++11 -Iapi -w -fpermissive
 TARGET=pict
+TARGET_LIB_SO=libpict.so
 TEST_OUTPUT = test/rel.log test/rel.log.failures test/dbg.log
 TEST_OUTPUT += test/.stdout test/.stderr
-OBJS = api/combination.o api/deriver.o api/exclusion.o
-OBJS += api/model.o api/parameter.o api/pictapi.o
-OBJS += api/task.o api/worklist.o cli/ccommon.o cli/cmdline.o
-OBJS += cli/common.o cli/cparser.o cli/ctokenizer.o cli/gcd.o
-OBJS += cli/gcdexcl.o cli/gcdmodel.o cli/model.o cli/mparser.o
-OBJS += cli/pict.o cli/strings.o
+OBJS = $(OBJS_API) $(OBJS_CLI)
+OBJS_API = api/combination.o api/deriver.o api/exclusion.o
+OBJS_API += api/model.o api/parameter.o api/pictapi.o
+OBJS_API += api/task.o api/worklist.o
+OBJS_CLI = cli/ccommon.o cli/cmdline.o
+OBJS_CLI += cli/common.o cli/cparser.o cli/ctokenizer.o cli/gcd.o
+OBJS_CLI += cli/gcdexcl.o cli/gcdmodel.o cli/model.o cli/mparser.o
+OBJS_CLI += cli/pict.o cli/strings.o
 
 pict: $(OBJS)
 	$(CXX) $(OBJS) -o $(TARGET)
+
+$(TARGET_LIB_SO): $(OBJS_API)
+	$(CXX) -fPIC -shared $(OBJS_API) -o $(TARGET_LIB_SO)
 
 test: $(TARGET)
 	cd test; perl test.pl ../$(TARGET) rel.log
 
 clean:
-	rm -f $(TARGET) $(TEST_OUTPUT) $(OBJS)
+	rm -f $(TARGET) $(TARGET_LIB_SO) $(TEST_OUTPUT) $(OBJS)
 
-all: pict
+all: pict $(TARGET_LIB_SO)
 
 source: clean
 	git archive --prefix="pict-$(COMMIT)/" -o "pict-$(SHORT_COMMIT).tar.gz" $(COMMIT)


### PR DESCRIPTION
This PR fixes the Makefile so that shared library that provides PICT API can be built.