### PR TITLE
Fix weights not being set in PictAddParameter()

### DIFF
--- a/api/pictapi.cpp
+++ b/api/pictapi.cpp
@@ -273,15 +273,15 @@ PictAddParameter
     {
         if( NULL != param )
         {
+            if( NULL != valueWeights )
+            {
+                std::vector<int> weights;
+                weights.reserve( valueCount );
+                weights.insert( weights.begin(), valueWeights, valueWeights + valueCount );
+                param->SetWeights(move(weights));
+            }
+
             modelObj->AddParameter( param );
-        }
-        
-        if( NULL != valueWeights )
-        {
-            std::vector<int> weights;
-            weights.reserve( valueCount );
-            weights.insert( weights.begin(), valueWeights, valueWeights + valueCount );
-            param->SetWeights(move(weights));
         }
     }
     catch( ... )

--- a/api/pictapi.cpp
+++ b/api/pictapi.cpp
@@ -281,6 +281,7 @@ PictAddParameter
             std::vector<int> weights;
             weights.reserve( valueCount );
             weights.insert( weights.begin(), valueWeights, valueWeights + valueCount );
+            param->SetWeights(move(weights));
         }
     }
     catch( ... )


### PR DESCRIPTION
The `weights` vector was getting filled, but it was never being assigned to `param`.