### PR TITLE
Fix mismatched new[]/delete[] pair

### DIFF
--- a/cli/pict.cpp
+++ b/cli/pict.cpp
@@ -163,7 +163,7 @@ int main
     // clean up
     for ( int ii = 0; ii < argc; ++ii )
     {
-        delete wargs[ ii ];
+        delete[] wargs[ ii ];
     }
     delete[] wargs;
 


### PR DESCRIPTION
Fix `delete` to balance new/delete pair.