### PR TITLE
Replace obsolete C++ API

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The test script produces a log: **dbg.log** or **rel.log** for the Debug and Rel
 
 ## Building with clang++ on Linux, OS/X, *BSD, etc.
 Install clang through your package manager (most systems), Xcode (OS/X), or from the [LLVM website](http://llvm.org/releases/).
-On Linux, you also need to install recent libstdc++ offered by gcc 5.
+On Linux, you also need to install recent GNU's "libstdc++" or LLVM's "libc++".
 
 Run `make` to build the `pict` binary.
 

--- a/api-usage/pictapi-sample.cpp
+++ b/api-usage/pictapi-sample.cpp
@@ -7,7 +7,7 @@ using namespace std;
 #define PAIRWISE 2
 
 #define checkNull( x )                                    \
-    if( NULL == x )                                       \
+    if( nullptr == x )                                    \
     {                                                     \
         wcout << L"Error: Out of memory" << endl;         \
         goto cleanup;                                     \
@@ -229,12 +229,12 @@ void __cdecl wmain()
 
 cleanup:
 
-    if( model != NULL )    
+    if( model != nullptr )
     {
         PictDeleteModel( model );
     }
 
-    if( task != NULL )    
+    if( task != nullptr )
     {
         PictDeleteTask( task );
     }

--- a/api/combination.cpp
+++ b/api/combination.cpp
@@ -190,7 +190,9 @@ void Combination::applyExclusion( Exclusion& excl, int index, ParamCollection::i
         // Is *pos a parameter in the exclusion?
         Exclusion::iterator ie = find_if( excl.begin(),
                                           excl.end(),
-                                          [pos](const ExclusionTerm et){ return et.first == *pos; } );
+                                          [pos](const ExclusionTerm et) {
+                                              return et.first == *pos;
+                                          } );
         // parameter is bound to a value in the exclusion
         if( excl.end() != ie )
         {

--- a/api/combination.cpp
+++ b/api/combination.cpp
@@ -190,7 +190,7 @@ void Combination::applyExclusion( Exclusion& excl, int index, ParamCollection::i
         // Is *pos a parameter in the exclusion?
         Exclusion::iterator ie = find_if( excl.begin(),
                                           excl.end(),
-                                          bind2nd( MatchParameterPointer(), *pos ) );
+                                          [pos](const ExclusionTerm et){ return et.first == *pos; } );
         // parameter is bound to a value in the exclusion
         if( excl.end() != ie )
         {

--- a/api/deriver.cpp
+++ b/api/deriver.cpp
@@ -332,7 +332,7 @@ void ExclusionDeriver::DeriveExclusions()
             // put ref to each exclusion in appropriate value-relative bucket
             // find this parameter in the exclusion
             Exclusion::iterator iExcl = find_if( ( *ie )->begin(), ( *ie )->end(),
-                                                 bind2nd( MatchParameterPointer(), m_currentParam ) );
+                                                 [this](const ExclusionTerm et){ return et.first == m_currentParam; } );
 
             // put the exclusion in the right bucket
             assert( iExcl != ( *ie )->end() );

--- a/api/deriver.cpp
+++ b/api/deriver.cpp
@@ -332,7 +332,9 @@ void ExclusionDeriver::DeriveExclusions()
             // put ref to each exclusion in appropriate value-relative bucket
             // find this parameter in the exclusion
             Exclusion::iterator iExcl = find_if( ( *ie )->begin(), ( *ie )->end(),
-                                                 [this](const ExclusionTerm et){ return et.first == m_currentParam; } );
+                                                 [this](const ExclusionTerm et) {
+                                                     return et.first == m_currentParam;
+                                                 } );
 
             // put the exclusion in the right bucket
             assert( iExcl != ( *ie )->end() );

--- a/api/generator.h
+++ b/api/generator.h
@@ -499,17 +499,6 @@ private:
 //
 //
 //
-struct MatchParameterPointer : public std::binary_function<ExclusionTerm, Parameter*, bool>
-{
-    bool operator()( const ExclusionTerm excl, Parameter* pParam ) const
-    {
-        return excl.first == pParam;
-    }
-};
-
-//
-//
-//
 class Model
 {
 public:

--- a/cli/common.cpp
+++ b/cli/common.cpp
@@ -51,8 +51,8 @@ void PrintMessage
     }
 
     wcerr << text1;
-    if ( text2 != NULL ) wcerr << L" " << text2;
-    if ( text3 != NULL ) wcerr << L" " << text3;
+    if ( text2 != nullptr ) wcerr << L" " << text2;
+    if ( text3 != nullptr ) wcerr << L" " << text3;
     wcerr << endl;
 }
 

--- a/cli/strings.cpp
+++ b/cli/strings.cpp
@@ -56,7 +56,7 @@ int stringCompare( const wstring& s1, const wstring& s2, bool caseSensitive )
 //
 //
 //
-wstring trim( wstring text)
+wstring trim( wstring text )
 {
     text.erase( text.begin(), find_if( text.begin(), text.end(), not1( ptr_fun<wint_t, int>( iswspace ) ) ) );
     text.erase( find_if( text.rbegin(), text.rend(), not1( ptr_fun<wint_t, int>( iswspace ) )).base(), text.end() );

--- a/cli/strings.cpp
+++ b/cli/strings.cpp
@@ -4,6 +4,7 @@
 #include <functional> 
 #include <cctype>
 #include <cwchar>
+#include <cwctype>
 #include <cassert>
 #include "strings.h"
 using namespace std;

--- a/cli/strings.cpp
+++ b/cli/strings.cpp
@@ -13,7 +13,7 @@ using namespace std;
 //
 wstring::iterator findFirstNonWhitespace( const wstring::iterator begin, const wstring::iterator end )
 {
-    return( find_if( begin, end, not1( ptr_fun<wint_t, int>( iswspace ) ) ) );
+    return( find_if( begin, end, [](const wint_t c){ return ! std::iswspace(c); } ) );
 }
 
 //
@@ -58,8 +58,8 @@ int stringCompare( const wstring& s1, const wstring& s2, bool caseSensitive )
 //
 wstring trim( wstring text )
 {
-    text.erase( text.begin(), find_if( text.begin(), text.end(), not1( ptr_fun<wint_t, int>( iswspace ) ) ) );
-    text.erase( find_if( text.rbegin(), text.rend(), not1( ptr_fun<wint_t, int>( iswspace ) )).base(), text.end() );
+    text.erase( text.begin(), find_if( text.begin(), text.end(), [](const wint_t c){ return ! std::iswspace(c); } ) );
+    text.erase( find_if( text.rbegin(), text.rend(), [](const wint_t c){ return ! std::iswspace(c); } ).base(), text.end() );
     return text;
 }
 

--- a/cli/strings.cpp
+++ b/cli/strings.cpp
@@ -13,7 +13,10 @@ using namespace std;
 //
 wstring::iterator findFirstNonWhitespace( const wstring::iterator begin, const wstring::iterator end )
 {
-    return( find_if( begin, end, [](const wint_t c){ return ! std::iswspace(c); } ) );
+    return( find_if( begin, end,
+                     [](const wint_t c) {
+                         return ! std::iswspace(c);
+                     } ) );
 }
 
 //
@@ -58,8 +61,16 @@ int stringCompare( const wstring& s1, const wstring& s2, bool caseSensitive )
 //
 wstring trim( wstring text )
 {
-    text.erase( text.begin(), find_if( text.begin(), text.end(), [](const wint_t c){ return ! std::iswspace(c); } ) );
-    text.erase( find_if( text.rbegin(), text.rend(), [](const wint_t c){ return ! std::iswspace(c); } ).base(), text.end() );
+    text.erase( text.begin(),
+                find_if( text.begin(), text.end(),
+                         [](const wint_t c) {
+                             return ! std::iswspace(c);
+                         } ) );
+    text.erase( find_if( text.rbegin(), text.rend(),
+                         [](const wint_t c) {
+                             return ! std::iswspace(c);
+                         } ).base(),
+                text.end() );
     return text;
 }
 


### PR DESCRIPTION
Replace obsolete C++ APIs like `bind2nd()`, `ptr_fun<>()`.

These APIs are obsoleted in C++11, and removed in C++17.
This fix also helps LLVM's `libc++`.
