### PR TITLE
Enable -pedantic on *nix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ else()
       -fno-omit-frame-pointer
       -fvisibility=hidden # By default, hide symbols on ELF binaries
       -g # add debug symbols for build pdb
+      -pedantic
   )
 
   # AppleClang is not accepting -flto as linker option

--- a/api/pictapi.cpp
+++ b/api/pictapi.cpp
@@ -21,7 +21,7 @@ PictCreateTask()
 {
     Task* taskObj = new Task();
     return( static_cast<PICT_HANDLE>( taskObj ) );
-};
+}
 
 //
 //
@@ -229,7 +229,7 @@ PictDeleteTask
 {
     Task* taskObj = static_cast<Task*>( NO_CONST_HANDLE( task ));
     delete( taskObj );
-};
+}
 
 //
 //
@@ -247,7 +247,7 @@ PictCreateModel
                                  randomSeed );
     
     return( static_cast<PICT_HANDLE>( modelObj ));   
-};
+}
 
 //
 //
@@ -335,7 +335,7 @@ PictAttachChildModel
     {
         return( PICT_OUT_OF_MEMORY );
     }
-};
+}
 
 //
 //


### PR DESCRIPTION
Using `-pedantic` raised some warnings on `g++`. This commit cleans up those warnings.