### PR TITLE
Enable warnings as error and W4 on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,8 @@ if (MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
   target_compile_options(${PICT_BUILD_OPTIONS}
     INTERFACE
-      /W3
+      /W4 /WX
+      /wd4189 # DOUT(arg) has unused parameters. Suppressing the warning here.
   )
 
   target_compile_definitions(${PICT_BUILD_OPTIONS}

--- a/api-usage/pictapi-sample.cpp
+++ b/api-usage/pictapi-sample.cpp
@@ -34,7 +34,6 @@ void __cdecl wmain()
     PICT_RET_CODE ret = PICT_SUCCESS;
 
     PICT_HANDLE task = PictCreateTask();
-    checkNull( task );
 
     //
     // In a general case,  models might form a tree-like hierarchy
@@ -42,6 +41,7 @@ void __cdecl wmain()
     //
 
     PICT_HANDLE model = PictCreateModel();
+    checkNull( task );
     checkNull( model );
 
     //

--- a/api/generator.h
+++ b/api/generator.h
@@ -270,7 +270,7 @@ public:
     }
 
     // for inserter() to work we need two-param insert
-    iterator insert( iterator pos, const ExclusionTerm& Term )
+    iterator insert( iterator, const ExclusionTerm& Term )
     {
         return insert( Term ).first;
     }

--- a/cli/ctokenizer.cpp
+++ b/cli/ctokenizer.cpp
@@ -532,9 +532,6 @@ RelationType ConstraintsTokenizer::getRelationType()
         else throw CSyntaxError( SyntaxErrorType::UnknownRelation, _currentPosition );
     }
     else throw CSyntaxError( SyntaxErrorType::UnknownRelation, _currentPosition );
-
-    assert( false );
-    return ( RelationType::Unknown );
 }
 
 //

--- a/cli/gcdmodel.cpp
+++ b/cli/gcdmodel.cpp
@@ -162,7 +162,8 @@ ErrorCode CGcdData::TranslateToGCD()
     {
         CModelParameter& param = _modelData.Parameters[ index ];
 
-        Parameter* gcdParam = new Parameter( UNDEFINED_ORDER, index, static_cast<int>( param.Values.size() ),
+        Parameter* gcdParam = new Parameter( UNDEFINED_ORDER, static_cast<int>(index),
+                                             static_cast<int>( param.Values.size() ),
                                              param.Name, param.IsResultParameter );
 
         // find out and assign weights to values

--- a/cli/model.h
+++ b/cli/model.h
@@ -61,7 +61,7 @@ public:
     CModelParameter() :
         Name(L""),
         IsResultParameter(false),
-        Order(UNDEFINED_ORDER),
+        Order(static_cast<unsigned int>(UNDEFINED_ORDER)),
         GcdPointer(nullptr){}
 
     int GetValueOrdinal( IN std::wstring& name, IN bool caseSensitive );

--- a/cli/mparser.cpp
+++ b/cli/mparser.cpp
@@ -134,7 +134,7 @@ bool CModelData::readParameter( wstring& line )
 
     wstring name = trim( line.substr( 0, paramSep ));
     
-    unsigned int order = UNDEFINED_ORDER;
+    unsigned int order = static_cast<unsigned int>(UNDEFINED_ORDER);
     
     //check if this param has custom-order defined
     wstrings nameAndOrder;

--- a/clidll/dllmain.cpp
+++ b/clidll/dllmain.cpp
@@ -1,9 +1,9 @@
 #if defined(_WIN32)
 #include "windows.h"
 
-BOOL APIENTRY DllMain( HMODULE hModule,
+BOOL APIENTRY DllMain( HMODULE /*hModule*/,
                        DWORD  ul_reason_for_call,
-                       LPVOID lpReserved
+                       LPVOID /*lpReserved*/
                      )
 {
     switch (ul_reason_for_call)


### PR DESCRIPTION
This commit increase warning level from `W3` to `W4` on MSVC and sets warnings as errors. Exclusion is made for a specific warning (C4189).