### PR TITLE
Enable warnings as error and W4 on MSVC

### DIFF
--- a/api-usage/pictapi-sample.cpp
+++ b/api-usage/pictapi-sample.cpp
@@ -41,6 +41,10 @@ void __cdecl wmain()
     //
 
     PICT_HANDLE model = PictCreateModel();
+
+    // We call this null check after calling PictCreateModel() to
+    // instantiate model. Otherwise, compiler flags that model
+    // might not be defined in checknull.
     checkNull( task );
     checkNull( model );
 


### PR DESCRIPTION
This commit increase warning level from `W3` to `W4` on MSVC and sets warnings as errors. Exclusion is made for a specific warning (C4189).