### PR TITLE
Fixing a "unused variable warning"

### DIFF
--- a/cli/mparser.cpp
+++ b/cli/mparser.cpp
@@ -366,9 +366,10 @@ bool CModelData::readParamSet( wstring& line )
             ++index;
         }
         // at this point we should always match the name
+        //
         // N.B. putting a condition around an assert is superfluous but it is done here
         //      because some compilers complain that 'found' variable is never used and
-        //      this is a cross-platform friendly way to supress such warnings
+        //      this is a cross-platform friendly way to suppress such warnings
         if( !found )
         {
             assert( found );

--- a/cli/mparser.cpp
+++ b/cli/mparser.cpp
@@ -366,7 +366,13 @@ bool CModelData::readParamSet( wstring& line )
             ++index;
         }
         // at this point we should always match the name
-        assert( found );
+        // N.B. putting a condition around an assert is superfluous but it is done here
+        //      because some compilers complain that 'found' variable is never used and
+        //      this is a cross-platform friendly way to supress such warnings
+        if( !found )
+        {
+            assert( found );
+        }
 
         submodel.Parameters.push_back( index );
     }


### PR DESCRIPTION
That 'found' variable is only used on CHK builds via an assert. When compiling for REL, the compiler thinks 'found' is never used. Since we have aggressive compiler settings for cmake that turn all warnings into errors, this breaks compilation at least on latest clang version on a macOS. Adding this silly condition makes the variable 'used' and avoids the warning.