### PR TITLE
Add std:: to resolve clang warn-error for arm64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 pict
 *.o
 .DS_Store
+build

--- a/api/pictapi.cpp
+++ b/api/pictapi.cpp
@@ -278,7 +278,7 @@ PictAddParameter
                 std::vector<int> weights;
                 weights.reserve( valueCount );
                 weights.insert( weights.begin(), valueWeights, valueWeights + valueCount );
-                param->SetWeights( move( weights ));
+                param->SetWeights( std::move( weights ));
             }
 
             modelObj->AddParameter( param );


### PR DESCRIPTION
The Clang 14.0.3 arm64-apple-darwin 23.0.0 toolchain treats the unqualified-std-cast-call warning as an error in the default configuration. 

This change does not impact behavior or function, but allows the PICT source to build on Apple devices without modification to the source, or to the CMake build configuration.