### PR TITLE
Fix a typo

### DIFF
--- a/cli/gcdexcl.cpp
+++ b/cli/gcdexcl.cpp
@@ -544,7 +544,7 @@ bool ConstraintsInterpreter::ConvertToExclusions( OUT CGcdExclusions& gcdExclusi
                 PrintMessage( InputDataError, L"Constraint definition is incorrect:", failureContext );
                 break;
             case SyntaxErrorType::NoConstraintEnd:
-                PrintMessage( InputDataError, L"Constraint terminated incorectly:", failureContext );
+                PrintMessage( InputDataError, L"Constraint terminated incorrectly:", failureContext );
                 break;
             case SyntaxErrorType::NoEndParenthesis:
                 PrintMessage( InputDataError, L"Missing closing parenthesis:", failureContext );

--- a/test/dbg-baseline.log
+++ b/test/dbg-baseline.log
@@ -44997,7 +44997,7 @@ STDOUT:
 +++++++++++++++++++++++++++++++++++
 
 STDERR:
-Input Error: Constraint terminated incorectly: if [G1] > "A" then [G2] > "f";
+Input Error: Constraint terminated incorrectly: if [G1] > "A" then [G2] > "f";
 
 
 
@@ -45261,7 +45261,7 @@ STDOUT:
 +++++++++++++++++++++++++++++++++++
 
 STDERR:
-Input Error: Constraint terminated incorectly: if [G1] > "A" then [G2] > 1q;
+Input Error: Constraint terminated incorrectly: if [G1] > "A" then [G2] > 1q;
 
 
 
@@ -45283,7 +45283,7 @@ STDOUT:
 +++++++++++++++++++++++++++++++++++
 
 STDERR:
-Input Error: Constraint terminated incorectly: if [G1] > "A" then [G2] > "f"
+Input Error: Constraint terminated incorrectly: if [G1] > "A" then [G2] > "f"
 
 
 
@@ -45327,7 +45327,7 @@ STDOUT:
 +++++++++++++++++++++++++++++++++++
 
 STDERR:
-Input Error: Constraint terminated incorectly: [G1] = "A" then [G2] = "g";
+Input Error: Constraint terminated incorrectly: [G1] = "A" then [G2] = "g";
 
 
 
@@ -46815,7 +46815,7 @@ STDOUT:
 +++++++++++++++++++++++++++++++++++
 
 STDERR:
-Input Error: Constraint terminated incorectly: if [e] not like "al*" then [a] > 1 els [c] > 1;
+Input Error: Constraint terminated incorrectly: if [e] not like "al*" then [a] > 1 els [c] > 1;
 
 
 
@@ -46859,7 +46859,7 @@ STDOUT:
 +++++++++++++++++++++++++++++++++++
 
 STDERR:
-Input Error: Constraint terminated incorectly: if not [f] like "al*" then [b] > 1 else [b] <= 1;
+Input Error: Constraint terminated incorrectly: if not [f] like "al*" then [b] > 1 else [b] <= 1;
 
 
 
@@ -69834,7 +69834,7 @@ STDOUT:
 +++++++++++++++++++++++++++++++++++
 
 STDERR:
-Input Error: Constraint terminated incorectly: if [A] = 2 then [B] = 3, [C] = 3;
+Input Error: Constraint terminated incorrectly: if [A] = 2 then [B] = 3, [C] = 3;
 
 
 
@@ -69856,7 +69856,7 @@ STDOUT:
 +++++++++++++++++++++++++++++++++++
 
 STDERR:
-Input Error: Constraint terminated incorectly: if [A] = 2 then [B] = 3, [C] = 3,;
+Input Error: Constraint terminated incorrectly: if [A] = 2 then [B] = 3, [C] = 3,;
 
 
 
@@ -69878,7 +69878,7 @@ STDOUT:
 +++++++++++++++++++++++++++++++++++
 
 STDERR:
-Input Error: Constraint terminated incorectly: if [A] = 2 then [B] = 3, ,[C]= 3;
+Input Error: Constraint terminated incorrectly: if [A] = 2 then [B] = 3, ,[C]= 3;
 
 
 
@@ -69900,7 +69900,7 @@ STDOUT:
 +++++++++++++++++++++++++++++++++++
 
 STDERR:
-Input Error: Constraint terminated incorectly: if ([A] = 2 or [A] = 1) and [F] = 1 then [B] = 3 ,[C] = 3, [C] = 2 , [D] = 1;
+Input Error: Constraint terminated incorrectly: if ([A] = 2 or [A] = 1) and [F] = 1 then [B] = 3 ,[C] = 3, [C] = 2 , [D] = 1;
 
 
 

--- a/test/rel-baseline.log
+++ b/test/rel-baseline.log
@@ -44992,7 +44992,7 @@ STDOUT:
 +++++++++++++++++++++++++++++++++++
 
 STDERR:
-Input Error: Constraint terminated incorectly: if [G1] > "A" then [G2] > "f";
+Input Error: Constraint terminated incorrectly: if [G1] > "A" then [G2] > "f";
 
 
 
@@ -45256,7 +45256,7 @@ STDOUT:
 +++++++++++++++++++++++++++++++++++
 
 STDERR:
-Input Error: Constraint terminated incorectly: if [G1] > "A" then [G2] > 1q;
+Input Error: Constraint terminated incorrectly: if [G1] > "A" then [G2] > 1q;
 
 
 
@@ -45278,7 +45278,7 @@ STDOUT:
 +++++++++++++++++++++++++++++++++++
 
 STDERR:
-Input Error: Constraint terminated incorectly: if [G1] > "A" then [G2] > "f"
+Input Error: Constraint terminated incorrectly: if [G1] > "A" then [G2] > "f"
 
 
 
@@ -45322,7 +45322,7 @@ STDOUT:
 +++++++++++++++++++++++++++++++++++
 
 STDERR:
-Input Error: Constraint terminated incorectly: [G1] = "A" then [G2] = "g";
+Input Error: Constraint terminated incorrectly: [G1] = "A" then [G2] = "g";
 
 
 
@@ -46810,7 +46810,7 @@ STDOUT:
 +++++++++++++++++++++++++++++++++++
 
 STDERR:
-Input Error: Constraint terminated incorectly: if [e] not like "al*" then [a] > 1 els [c] > 1;
+Input Error: Constraint terminated incorrectly: if [e] not like "al*" then [a] > 1 els [c] > 1;
 
 
 
@@ -46854,7 +46854,7 @@ STDOUT:
 +++++++++++++++++++++++++++++++++++
 
 STDERR:
-Input Error: Constraint terminated incorectly: if not [f] like "al*" then [b] > 1 else [b] <= 1;
+Input Error: Constraint terminated incorrectly: if not [f] like "al*" then [b] > 1 else [b] <= 1;
 
 
 
@@ -69829,7 +69829,7 @@ STDOUT:
 +++++++++++++++++++++++++++++++++++
 
 STDERR:
-Input Error: Constraint terminated incorectly: if [A] = 2 then [B] = 3, [C] = 3;
+Input Error: Constraint terminated incorrectly: if [A] = 2 then [B] = 3, [C] = 3;
 
 
 
@@ -69851,7 +69851,7 @@ STDOUT:
 +++++++++++++++++++++++++++++++++++
 
 STDERR:
-Input Error: Constraint terminated incorectly: if [A] = 2 then [B] = 3, [C] = 3,;
+Input Error: Constraint terminated incorrectly: if [A] = 2 then [B] = 3, [C] = 3,;
 
 
 
@@ -69873,7 +69873,7 @@ STDOUT:
 +++++++++++++++++++++++++++++++++++
 
 STDERR:
-Input Error: Constraint terminated incorectly: if [A] = 2 then [B] = 3, ,[C]= 3;
+Input Error: Constraint terminated incorrectly: if [A] = 2 then [B] = 3, ,[C]= 3;
 
 
 
@@ -69895,7 +69895,7 @@ STDOUT:
 +++++++++++++++++++++++++++++++++++
 
 STDERR:
-Input Error: Constraint terminated incorectly: if ([A] = 2 or [A] = 1) and [F] = 1 then [B] = 3 ,[C] = 3, [C] = 2 , [D] = 1;
+Input Error: Constraint terminated incorrectly: if ([A] = 2 or [A] = 1) and [F] = 1 then [B] = 3 ,[C] = 3, [C] = 2 , [D] = 1;
 
 
 


### PR DESCRIPTION
Change from _incorectly_ to _inco**r**rectly_

And here is a problem. I use `ripgrep` to find all *incorectly*s:

```
> rg 'incorectly'
cli\gcdexcl.cpp
547:                PrintMessage( InputDataError, L"Constraint terminated incorectly:", failureContext );

test\dbg-baseline.log
45000:Input Error: Constraint terminated incorectly: if [G1] > "A" then [G2] > "f";
45264:Input Error: Constraint terminated incorectly: if [G1] > "A" then [G2] > 1q;
45286:Input Error: Constraint terminated incorectly: if [G1] > "A" then [G2] > "f"
45330:Input Error: Constraint terminated incorectly: [G1] = "A" then [G2] = "g";
46818:Input Error: Constraint terminated incorectly: if [e] not like "al*" then [a] > 1 els [c] > 1;
46862:Input Error: Constraint terminated incorectly: if not [f] like "al*" then [b] > 1 else [b] <= 1;
69837:Input Error: Constraint terminated incorectly: if [A] = 2 then [B] = 3, [C] = 3;
69859:Input Error: Constraint terminated incorectly: if [A] = 2 then [B] = 3, [C] = 3,;
69881:Input Error: Constraint terminated incorectly: if [A] = 2 then [B] = 3, ,[C]= 3;
69903:Input Error: Constraint terminated incorectly: if ([A] = 2 or [A] = 1) and [F] = 1 then [B] = 3 ,[C] = 3, [C] = 2 , [D] = 1;

test\rel-baseline.log
44995:Input Error: Constraint terminated incorectly: if [G1] > "A" then [G2] > "f";
45259:Input Error: Constraint terminated incorectly: if [G1] > "A" then [G2] > 1q;
45281:Input Error: Constraint terminated incorectly: if [G1] > "A" then [G2] > "f"
45325:Input Error: Constraint terminated incorectly: [G1] = "A" then [G2] = "g";
46813:Input Error: Constraint terminated incorectly: if [e] not like "al*" then [a] > 1 els [c] > 1;
46857:Input Error: Constraint terminated incorectly: if not [f] like "al*" then [b] > 1 else [b] <= 1;
69832:Input Error: Constraint terminated incorectly: if [A] = 2 then [B] = 3, [C] = 3;
69854:Input Error: Constraint terminated incorectly: if [A] = 2 then [B] = 3, [C] = 3,;
69876:Input Error: Constraint terminated incorectly: if [A] = 2 then [B] = 3, ,[C]= 3;
69898:Input Error: Constraint terminated incorectly: if ([A] = 2 or [A] = 1) and [F] = 1 then [B] = 3 ,[C] = 3, [C] = 2 , [D] = 1;
```

Seems these baseline logs are wrong too, and I should change them. But since the two logs' last change is done 9 years ago, I'm not sure whether I should change them too.

If there's anything else I need to do, please let me know and I'll be happy to assist.

 