### PR TITLE
docs(readme): fix typo in CTest argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Assuming installation of CMake and C++ toolchain, following set of commands will
 ```
 > cmake -DCMAKE_BUILD_TYPE=Release -S . -B build
 > cmake --build build
-> pushd build && ctest -v && popd
+> pushd build && ctest -V && popd
 ```
 
 ## Debugging


### PR DESCRIPTION
`-v` is not a CTest argument as far as I'm aware, `-V` is used for verbose output.