### PR TITLE
docs: align constraints grammar with current implementation

### DIFF
--- a/doc/pict.md
+++ b/doc/pict.md
@@ -456,6 +456,7 @@ These are best to avoid in any case. When seeding is used, you will be warned if
 
     Constraint    :: =
       IF Predicate THEN Predicate ELSE Predicate;
+    | IF Predicate THEN Predicate;
     | Predicate;
 
     Predicate     :: =
@@ -470,7 +471,9 @@ These are best to avoid in any case. When seeding is used, you will be warned if
     Term          :: =
       ParameterName Relation Value
     | ParameterName LIKE PatternString
+    | ParameterName NOT LIKE PatternString
     | ParameterName IN { ValueSet }
+    | ParameterName NOT IN { ValueSet }
     | ParameterName Relation ParameterName
 
     ValueSet       :: =


### PR DESCRIPTION
## Summary

The constraints grammar in `doc/pict.md` is missing a few productions that are supported by the implementation in `cli/ctokenizer.cpp`.

- **`IF ... THEN ...;` (without ELSE)**: The grammar only lists `IF Predicate THEN Predicate ELSE Predicate;` but ELSE is optional in the implementation (`parseConstraint()`). The document's own examples also use this form, e.g. `IF [File system] = "FAT" THEN [Size] <= 4096;`
  - ref: https://github.com/microsoft/pict/blob/c3dad2bb24d08c9967565e0ca48e1a152216d1d4/cli/ctokenizer.cpp#L148-L157

- **`NOT IN` / `NOT LIKE`**: `getRelationType()` handles these as compound relation operators, but they are not listed in the grammar.
  - ref: https://github.com/microsoft/pict/blob/c3dad2bb24d08c9967565e0ca48e1a152216d1d4/cli/ctokenizer.cpp#L528-L533

No behavioral changes. Documentation only.