### PR TITLE
User/daspr/performanceimprovements

### DIFF
--- a/Microsoft.Test.Pict.nuspec
+++ b/Microsoft.Test.Pict.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
 	<metadata>
 		<id>Microsoft.Test.Pict</id>
-		<version>3.8.0</version>
+		<version>3.9.0</version>
 		<authors>Jacek Czerwonka</authors>
 		<license type="file">contents/LICENSE.TXT</license>
 		<projectUrl>http://github.com/microsoft/pict</projectUrl>

--- a/api-usage/pictapi-sample.cpp
+++ b/api-usage/pictapi-sample.cpp
@@ -165,6 +165,21 @@ void __cdecl wmain()
     checkRetCode( ret );
 
     //
+    // Optionally let the engine use multiple worker threads to speed up a single
+    // generation. This is purely a performance knob: the generated test suite is
+    // bit-for-bit identical regardless of the thread count (same seed always yields
+    // the same output), so it is safe to enable for any model.
+    //
+    //   0 = auto (use the machine's hardware concurrency)
+    //   1 = serial (the default if this is never called)
+    //   N = use N worker threads
+    //
+    // It must be called before PictGenerate. Larger, higher-order models benefit
+    // the most. Tiny models automatically fall back to serial.
+    //
+    PictSetThreadCount( task, 0 );
+
+    //
     // The main event: generation.
     //
 

--- a/api-usage/pictapi-sample.cpp
+++ b/api-usage/pictapi-sample.cpp
@@ -33,7 +33,9 @@ void __cdecl wmain()
 {
     PICT_RET_CODE ret = PICT_SUCCESS;
 
-    PICT_HANDLE task = PictCreateTask();
+    // Use 0 to select the machine's hardware concurrency. PictCreateTask() remains
+    // available for callers that want the serial default.
+    PICT_HANDLE task = PictCreateTaskWithThreadCount( 0 );
 
     //
     // In a general case,  models might form a tree-like hierarchy
@@ -163,21 +165,6 @@ void __cdecl wmain()
 
     ret = PictAddSeed( task, seed1, SEED_1_SIZE );
     checkRetCode( ret );
-
-    //
-    // Optionally let the engine use multiple worker threads to speed up a single
-    // generation. This is purely a performance knob: the generated test suite is
-    // bit-for-bit identical regardless of the thread count (same seed always yields
-    // the same output), so it is safe to enable for any model.
-    //
-    //   0 = auto (use the machine's hardware concurrency)
-    //   1 = serial (the default if this is never called)
-    //   N = use N worker threads
-    //
-    // It must be called before PictGenerate. Larger, higher-order models benefit
-    // the most. Tiny models automatically fall back to serial.
-    //
-    PictSetThreadCount( task, 0 );
 
     //
     // The main event: generation.

--- a/api/combination.cpp
+++ b/api/combination.cpp
@@ -4,8 +4,6 @@
 namespace pictcore
 {
 
-unsigned int Combination::m_lastUsedId = UNDEFINED_ID;
-
 //
 //
 //
@@ -264,7 +262,7 @@ void Combination::SetOpen( int index )
 Combination::Combination( Model *M ) :
     m_bitvec( nullptr ), m_range( 0 ), m_openCount( 0 ), m_boundCount( 0 ), m_model( M )
 {
-    m_id = ++m_lastUsedId;
+    m_id = m_model->GetTask()->NextCombinationId();
     DOUT( L"Combination created: " << m_id << endl );
 }
 

--- a/api/deriver.cpp
+++ b/api/deriver.cpp
@@ -247,20 +247,16 @@ inline void ExclusionDeriver::buildExclusion( Exclusion& exclImplied, vector<Exc
 //
 // Given an exclusion, the function returns true if m_exclusions already has 
 //    this or a more general exclusion
-// This function makes a use of buckets to check only against those exclusions
-//    in m_exclusions which have at least one element of the given one
+// A stored exclusion is "more general" when its term set is a subset of excl's.
+//    Because both the stored keys and excl are sorted with the same ordering,
+//    this subset test is a polynomial-time trie walk (find_subset). It replaces
+//    an earlier approach that probed every permutation of excl (O(k!)), which
+//    made derivation intractable for models with large derived exclusions.
 //
 inline bool ExclusionDeriver::alreadyInCollection( Exclusion &excl )
 {
-    // for all permutations
     sort( excl.lbegin(), excl.lend() );
-    bool more = true;
-    while( more )
-    {
-        if( m_lookup.find_prefix( excl.GetList() ) ) return true;
-        more = next_permutation( excl.lbegin(), excl.lend() );
-    }
-    return false;
+    return m_lookup.find_subset( excl.GetList() );
 }
 
 //

--- a/api/generator.h
+++ b/api/generator.h
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <algorithm>
 #include <functional>
+#include <utility>
 #include <cassert>
 #include "threadpool.h"
 
@@ -650,7 +651,7 @@ private:
 class Task
 {
 public:
-    Task();
+    explicit Task( size_t maxThreads = 1 );
     ~Task();
 
     // this has to be called right before generation starts
@@ -683,19 +684,12 @@ public:
     unsigned int NextCombinationId() { return ++m_combinationId; }
 
     //
-    // Engine-level parallelism. Worker threads are created lazily on first use
-    // and reused across the whole generation. ParallelFor preserves determinism:
-    // it only runs pure per-index work; callers serialize selection and RNG draws.
-    //
-    void   SetMaxThreads( size_t n ) { m_maxThreads = ( n < 1 ) ? 1 : n; }
-    size_t GetMaxThreads() const     { return m_maxThreads; }
-
-    // Returns the (lazily started) worker pool. Call pool.ParallelFor(...) from the
-    // generation thread; it runs serial automatically when m_maxThreads <= 1.
-    ThreadPool& Pool()
+    // Worker threads are created lazily and reused across the whole generation.
+    // ParallelFor preserves determinism: callers serialize selection and RNG draws.
+    template<class Fn>
+    void ParallelFor( size_t begin, size_t end, size_t grain, Fn&& fn )
     {
-        m_pool.EnsureStarted( m_maxThreads );
-        return m_pool;
+        m_pool.ParallelFor( begin, end, grain, std::forward<Fn>( fn ) );
     }
 
     void SetRootModel( Model* model )
@@ -758,9 +752,8 @@ private:
     unsigned int m_randState     = 1;
     unsigned int m_combinationId = UNDEFINED_ID;
 
-    // engine-level worker pool and the desired total thread count (1 = serial)
+    // engine-level worker pool (configured once when the Task is constructed)
     ThreadPool m_pool;
-    size_t     m_maxThreads = 1;
 
     // result row pointer allows C-style API to implement GetNextResultRow function
     // i.e. get one result row at a time

--- a/api/generator.h
+++ b/api/generator.h
@@ -15,7 +15,6 @@
 #include <iostream>
 #include <algorithm>
 #include <functional>
-#include <utility>
 #include <cassert>
 #include "threadpool.h"
 
@@ -686,10 +685,9 @@ public:
     //
     // Worker threads are created lazily and reused across the whole generation.
     // ParallelFor preserves determinism: callers serialize selection and RNG draws.
-    template<class Fn>
-    void ParallelFor( size_t begin, size_t end, size_t grain, Fn&& fn )
+    void ParallelFor( size_t begin, size_t end, size_t grain, std::function<void( size_t )> fn )
     {
-        m_pool.ParallelFor( begin, end, grain, std::forward<Fn>( fn ) );
+        m_pool.ParallelFor( begin, end, grain, fn );
     }
 
     void SetRootModel( Model* model )

--- a/api/generator.h
+++ b/api/generator.h
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <functional>
 #include <cassert>
+#include "threadpool.h"
 
 //
 // Logging facility
@@ -254,7 +255,8 @@ public:
     size_t size()  const         { return( col.size() ); }
     bool   empty() const         { return( col.empty() ); }
 
-    // exclusion represented as a list, for next_permutation to work
+    // exclusion also represented as a sortable list, used as a trie key for
+    // subset lookups (see trie::find_subset)
     _ExclusionVec::iterator lbegin() { return( vec.begin() ); }
     _ExclusionVec::iterator lend()   { return( vec.end() ); }
     _ExclusionVec &GetList()         { return( vec ); }
@@ -301,7 +303,6 @@ public:
     Combination( Model* model );
     ~Combination();
 
-    static void ResetId() { m_lastUsedId = UNDEFINED_ID; }
     unsigned int GetId()  { return m_id; }
 
     void WireModel( Model* model ) { m_model = model; }
@@ -342,7 +343,6 @@ public:
     }
 
 private:
-    static unsigned int m_lastUsedId; // static source of identifiers
     unsigned int        m_id;         // unique identifier of this instance
 
     ParamCollection m_params;
@@ -542,7 +542,6 @@ public:
     void SetRandomSeed( long seed )
     {
         m_randomSeed = seed;
-        srand( m_randomSeed );
         for( auto & submodel : m_submodels ) submodel->SetRandomSeed( m_randomSeed );
     }
 
@@ -663,6 +662,42 @@ public:
 
     void DeallocWorkbuf();
 
+    //
+    // Per-Task pseudo-random source. Replaces the process-global C srand()/rand()
+    // so that independent Tasks are thread-safe and each Task deterministically
+    // reproduces its own seed's output. The algorithm intentionally mirrors the
+    // MSVC CRT rand() LCG so output stays bit-identical to the previous global rand().
+    //
+    void SeedRandom( unsigned int seed ) { m_randState = seed; }
+    int  Rand()
+    {
+        m_randState = m_randState * 214013u + 2531011u;
+        return static_cast<int>( ( m_randState >> 16 ) & 0x7fff );
+    }
+
+    //
+    // Per-Task source of Combination identifiers. Replaces the previous static
+    // counter so concurrent Tasks cannot corrupt each other's deterministic
+    // combination ordering.
+    //
+    unsigned int NextCombinationId() { return ++m_combinationId; }
+
+    //
+    // Engine-level parallelism. Worker threads are created lazily on first use
+    // and reused across the whole generation. ParallelFor preserves determinism:
+    // it only runs pure per-index work; callers serialize selection and RNG draws.
+    //
+    void   SetMaxThreads( size_t n ) { m_maxThreads = ( n < 1 ) ? 1 : n; }
+    size_t GetMaxThreads() const     { return m_maxThreads; }
+
+    // Returns the (lazily started) worker pool. Call pool.ParallelFor(...) from the
+    // generation thread; it runs serial automatically when m_maxThreads <= 1.
+    ThreadPool& Pool()
+    {
+        m_pool.EnsureStarted( m_maxThreads );
+        return m_pool;
+    }
+
     void SetRootModel( Model* model )
     {
         m_rootModel = model;
@@ -718,6 +753,14 @@ private:
 
     // a global workspace shared by multiple objects
     int* m_workbuf = nullptr;
+
+    // per-Task RNG state (MSVC rand()-compatible) and Combination id counter
+    unsigned int m_randState     = 1;
+    unsigned int m_combinationId = UNDEFINED_ID;
+
+    // engine-level worker pool and the desired total thread count (1 = serial)
+    ThreadPool m_pool;
+    size_t     m_maxThreads = 1;
 
     // result row pointer allows C-style API to implement GetNextResultRow function
     // i.e. get one result row at a time

--- a/api/model.cpp
+++ b/api/model.cpp
@@ -6,6 +6,13 @@ namespace pictcore
 {
 
 //
+// Engine parallelism tuning. Only parallelize a per-combination scan when
+// there are enough combinations to amortize synchronization.
+//
+static const size_t kGcdScanParallelThreshold = 64;
+static const size_t kGcdScanGrain             = 8;
+
+//
 // function object to sort parameters in decreasing combinatorial order
 //
 class GreaterThanByOrder {
@@ -223,61 +230,96 @@ void Model::gcd( ComboCollection &vecCombo )
                 {
                     DOUT( L"Empty worklist: finding a seed combination.\n" );
                     // pick a zero from feasible combination with the most zeros, bind corresponding values
+
+                    // Compute (open, match) for every not-fully-bound combination. 
+                    // Feasible(int) is read-only and uses no shared scratch buffer,
+                    // so this is safe to run concurrently.
+                    // Fully-bound combos keep the -1 sentinel and are skipped below.
+                    const size_t nCombos = vecCombo.size();
+                    std::vector<int> openA( nCombos, -1 );
+                    std::vector<int> matchA( nCombos, -1 );
+
+                    auto computeFeasibility = [&]( size_t cidx )
+                    {
+                        Combination* combo = vecCombo[ cidx ];
+                        if( combo->IsFullyBound() ) return;
+
+                        int open  = 0;
+                        int match = 0;
+                        for( int vidx = 0; vidx < combo->GetRange(); ++vidx )
+                        {
+                            ComboStatus status = combo->Feasible( vidx );
+                            if( ComboStatus::Open == status )
+                            {
+                                ++open;
+                            }
+                            else if( ComboStatus::CoveredMatch == status )
+                            {
+                                ++match;
+                            }
+                        }
+                        openA[ cidx ]  = open;
+                        matchA[ cidx ] = match;
+                    };
+
+                    if( GetTask()->GetMaxThreads() > 1 && nCombos >= kGcdScanParallelThreshold )
+                    {
+                        GetTask()->Pool().ParallelFor( 0, nCombos, kGcdScanGrain, computeFeasibility );
+                    }
+                    else
+                    {
+                        for( size_t cidx = 0; cidx < nCombos; ++cidx )
+                        {
+                            computeFeasibility( cidx );
+                        }
+                    }
+
+                    // Phase 2 (serial): selection. Iterates combos in original order
+                    // and draws the RNG under exactly the same conditions as before,
+                    // so the chosen combination is bit-for-bit identical to serial.
                     int maxZeros = 0;
                     int maxMatch = 0;
                     int ties     = 0;
                     int choice   = -1;
-                    for( int cidx = 0; cidx < static_cast<int>( vecCombo.size() ); ++cidx )
+                    for( int cidx = 0; cidx < static_cast<int>( nCombos ); ++cidx )
                     {
-                        if( !vecCombo[ cidx ]->IsFullyBound() )
+                        if( openA[ cidx ] < 0 )
                         {
-                            int open  = 0;
-                            int match = 0;
+                            continue; // fully bound; was skipped by the original guard
+                        }
 
-                            // Make sure there's a feasible value set
-                            for( int vidx = 0; vidx < vecCombo[ cidx ]->GetRange(); ++vidx )
-                            {
-                                ComboStatus status = vecCombo[ cidx ]->Feasible( vidx );
-                                if( ComboStatus::Open == status )
-                                {
-                                    ++open;
-                                }
-                                else if( ComboStatus::CoveredMatch == status )
-                                {
-                                    ++match;
-                                }
-                            }
+                        int open  = openA[ cidx ];
+                        int match = matchA[ cidx ];
 
-                            // if combo has the most zeros
-                            if( open > maxZeros )
-                            {
-                                choice   = cidx;
-                                ties     = 1;
-                                maxZeros = open;
-                            }
-                            // if number of zeros ties up with some previous choice, pick randomly
-                            else if( open == maxZeros
-                                 &&  maxZeros > 0
-                                 &&  !( rand() % ++ties ) )
-                            {
-                                choice = cidx;
-                            }
-                            // no zeros were found anywhere yet, pick the best matching one
-                            else if( maxZeros == 0
-                                 &&  match > maxMatch )
-                            {
-                                choice = cidx;
-                                ties = 1;
-                                maxMatch = match;
-                            }
-                            // if there's a tie in match, pick randomly
-                            else if( maxZeros == 0
-                                 &&  match > 0
-                                 &&  match == maxMatch
-                                 &&  !( rand() % ++ties ) )
-                            {
-                                choice = cidx;
-                            }
+                        // if combo has the most zeros
+                        if( open > maxZeros )
+                        {
+                            choice   = cidx;
+                            ties     = 1;
+                            maxZeros = open;
+                        }
+                        // if number of zeros ties up with some previous choice, pick randomly
+                        else if( open == maxZeros
+                             &&  maxZeros > 0
+                             &&  !( GetTask()->Rand() % ++ties ) )
+                        {
+                            choice = cidx;
+                        }
+                        // no zeros were found anywhere yet, pick the best matching one
+                        else if( maxZeros == 0
+                             &&  match > maxMatch )
+                        {
+                            choice = cidx;
+                            ties = 1;
+                            maxMatch = match;
+                        }
+                        // if there's a tie in match, pick randomly
+                        else if( maxZeros == 0
+                             &&  match > 0
+                             &&  match == maxMatch
+                             &&  !( GetTask()->Rand() % ++ties ) )
+                        {
+                            choice = cidx;
                         }
                     } // for cidx
                     assert( choice != -1 );
@@ -299,7 +341,7 @@ void Model::gcd( ComboCollection &vecCombo )
                                 // Pick a value using weighted random choice
                                 int weight = vecCombo[ choice ]->Weight( vidx );
                                 totalWeight += weight;
-                                if( rand() % totalWeight < weight )
+                                if( GetTask()->Rand() % totalWeight < weight )
                                 {
                                     bestValue = vidx;
                                 }
@@ -331,7 +373,7 @@ void Model::gcd( ComboCollection &vecCombo )
                         }
 #endif
                         assert( !candidates.empty() );
-                        int zeroVal = candidates[ rand() % candidates.size() ];
+                        int zeroVal = candidates[ GetTask()->Rand() % candidates.size() ];
                         DOUT( L"Chose value " << zeroVal << L", unbound count was " << unbound << L".\n" );
                         // Bind the values corresponding to the zero
                         unbound -= vecCombo[ choice ]->Bind( zeroVal, worklist );
@@ -987,7 +1029,7 @@ Exclusion Model::generateRandomRow()
         {
             sum += ( *ip )->GetWeight( i );
         }
-        int idx = rand() % sum;
+        int idx = GetTask()->Rand() % sum;
 
         int n;
         int val = 0;

--- a/api/model.cpp
+++ b/api/model.cpp
@@ -262,9 +262,9 @@ void Model::gcd( ComboCollection &vecCombo )
                         matchA[ cidx ] = match;
                     };
 
-                    if( GetTask()->GetMaxThreads() > 1 && nCombos >= kGcdScanParallelThreshold )
+                    if( nCombos >= kGcdScanParallelThreshold )
                     {
-                        GetTask()->Pool().ParallelFor( 0, nCombos, kGcdScanGrain, computeFeasibility );
+                        GetTask()->ParallelFor( 0, nCombos, kGcdScanGrain, computeFeasibility );
                     }
                     else
                     {
@@ -283,7 +283,7 @@ void Model::gcd( ComboCollection &vecCombo )
                     int choice   = -1;
                     for( int cidx = 0; cidx < static_cast<int>( nCombos ); ++cidx )
                     {
-                        if( openA[ cidx ] < 0 )
+                        if( openA[ cidx ] == -1 )
                         {
                             continue; // fully bound; was skipped by the original guard
                         }

--- a/api/parameter.cpp
+++ b/api/parameter.cpp
@@ -112,12 +112,12 @@ int Parameter::PickValue()
                 // Arbitrary choice - we already have this parameter covered
                 // Use weights if they exist
                 bestValueCount += GetWeight(value);
-                if (rand() % bestValueCount < GetWeight(value))
+                if (m_task->Rand() % bestValueCount < GetWeight(value))
                 {
                     bestValue = value;
                 }
             }
-            else if (totalZeros == maxTotal && !(rand() % ++bestValueCount))
+            else if (totalZeros == maxTotal && !(m_task->Rand() % ++bestValueCount))
             {
                 bestValue = value;
                 maxTotal  = totalZeros;

--- a/api/pict.def
+++ b/api/pict.def
@@ -1,6 +1,7 @@
 LIBRARY    pict
 EXPORTS
     PictCreateTask
+    PictCreateTaskWithThreadCount
     PictAddExclusion
     PictAddSeed
     PictGenerate
@@ -10,7 +11,6 @@ EXPORTS
     PictResetResultFetching
     PictGetNextResultRow
     PictSetRootModel
-    PictSetThreadCount
     PictGetTotalParameterCount
     PictDeleteTask
     PictCreateModel

--- a/api/pict.def
+++ b/api/pict.def
@@ -10,6 +10,7 @@ EXPORTS
     PictResetResultFetching
     PictGetNextResultRow
     PictSetRootModel
+    PictSetThreadCount
     PictGetTotalParameterCount
     PictDeleteTask
     PictCreateModel

--- a/api/pictapi.cpp
+++ b/api/pictapi.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <thread>
 using namespace std;
 
 #include "pictapi.h"
@@ -36,6 +37,36 @@ PictSetRootModel
 {
     Task* taskObj = static_cast<Task*>( NO_CONST_HANDLE( task ));
     taskObj->SetRootModel( static_cast<Model*>( NO_CONST_HANDLE( model )));
+}
+
+//
+// Sets how many worker threads the engine may use to parallelize a single
+// generation. This is purely a performance knob: the produced test suite is
+// bit-for-bit identical regardless of the thread count (same seed -> same output).
+//
+//   threadCount == 0  -> auto (std::thread::hardware_concurrency)
+//   threadCount == 1  -> serial (default; unchanged behavior)
+//   threadCount  > 1  -> use that many threads
+//
+// Must be called before PictGenerate.
+//
+void
+API_SPEC
+PictSetThreadCount
+    (
+    IN const PICT_HANDLE task,
+    IN       size_t      threadCount
+    )
+{
+    Task* taskObj = static_cast<Task*>( NO_CONST_HANDLE( task ));
+
+    if( threadCount == 0 )
+    {
+        unsigned int detected = std::thread::hardware_concurrency();
+        threadCount = ( detected == 0 ) ? 1 : static_cast<size_t>( detected );
+    }
+
+    taskObj->SetMaxThreads( threadCount );
 }
 
 //
@@ -125,6 +156,7 @@ PictGenerate
     }
     
     Model* root = taskObj->GetRootModel();
+    taskObj->SeedRandom( static_cast<unsigned int>( root->GetRandomSeed() ) );
     try
     {
         generate( root );

--- a/api/pictapi.cpp
+++ b/api/pictapi.cpp
@@ -25,6 +25,27 @@ PictCreateTask()
 }
 
 //
+// Allocates a task with a fixed engine thread count. Worker threads are created
+// lazily on first use and retained for the lifetime of the task.
+//
+PICT_HANDLE
+API_SPEC
+PictCreateTaskWithThreadCount
+    (
+    IN size_t threadCount
+    )
+{
+    if( threadCount == 0 )
+    {
+        unsigned int detected = std::thread::hardware_concurrency();
+        threadCount = ( detected == 0 ) ? 1 : static_cast<size_t>( detected );
+    }
+
+    Task* taskObj = new Task( threadCount );
+    return( static_cast<PICT_HANDLE>( taskObj ) );
+}
+
+//
 //
 //
 void
@@ -37,36 +58,6 @@ PictSetRootModel
 {
     Task* taskObj = static_cast<Task*>( NO_CONST_HANDLE( task ));
     taskObj->SetRootModel( static_cast<Model*>( NO_CONST_HANDLE( model )));
-}
-
-//
-// Sets how many worker threads the engine may use to parallelize a single
-// generation. This is purely a performance knob: the produced test suite is
-// bit-for-bit identical regardless of the thread count (same seed -> same output).
-//
-//   threadCount == 0  -> auto (std::thread::hardware_concurrency)
-//   threadCount == 1  -> serial (default; unchanged behavior)
-//   threadCount  > 1  -> use that many threads
-//
-// Must be called before PictGenerate.
-//
-void
-API_SPEC
-PictSetThreadCount
-    (
-    IN const PICT_HANDLE task,
-    IN       size_t      threadCount
-    )
-{
-    Task* taskObj = static_cast<Task*>( NO_CONST_HANDLE( task ));
-
-    if( threadCount == 0 )
-    {
-        unsigned int detected = std::thread::hardware_concurrency();
-        threadCount = ( detected == 0 ) ? 1 : static_cast<size_t>( detected );
-    }
-
-    taskObj->SetMaxThreads( threadCount );
 }
 
 //

--- a/api/pictapi.h
+++ b/api/pictapi.h
@@ -105,6 +105,29 @@ PictSetRootModel
 
 // ////////////////////////////////////////////////////////////////////////////
 //
+// Sets how many worker threads the engine may use to parallelize a single
+// generation. Performance only: output is bit-for-bit identical regardless of the
+// thread count (same seed -> same test suite). Must be called before PictGenerate.
+//
+// Parameters:
+//   task         Valid handle of a task
+//   threadCount  0 = auto (hardware concurrency), 1 = serial (default), N = N threads
+//
+// Returns:
+//   Nothing
+//
+// ////////////////////////////////////////////////////////////////////////////
+
+void
+API_SPEC
+PictSetThreadCount
+    (
+    IN const PICT_HANDLE task,
+    IN       size_t      threadCount
+    );
+
+// ////////////////////////////////////////////////////////////////////////////
+//
 // Adds an exclusion to the task.  Exclusions define combinations  which should
 // not appear in the output. Such a combination has a variable number of items.
 // Each item is a pair consisting of a pointer to the involved parameter and a

--- a/api/pictapi.h
+++ b/api/pictapi.h
@@ -84,12 +84,34 @@ PictCreateTask();
 
 // ////////////////////////////////////////////////////////////////////////////
 //
+// Allocates a new task with a fixed engine thread count. Performance only: output
+// is bit-for-bit identical regardless of the thread count (same seed -> same test
+// suite). Worker threads are created lazily on first use.
+//
+// Parameters:
+//   threadCount  0 = auto (hardware concurrency), 1 = serial, N = N threads
+//
+// Returns:
+//   Non-nullptr   Allocation succeeded (a handle is returned)
+//   nullptr       Allocation failed
+//
+// ////////////////////////////////////////////////////////////////////////////
+
+PICT_HANDLE
+API_SPEC
+PictCreateTaskWithThreadCount
+    (
+    IN size_t threadCount
+    );
+
+// ////////////////////////////////////////////////////////////////////////////
+//
 // Associates a model tree with a task.
 //
 // Parameters:
 //   task      Valid handle of a task
 //   model     Valid handle of the root of the model hierarchy
-// 
+//
 // Returns:
 //   Nothing
 //
@@ -101,29 +123,6 @@ PictSetRootModel
     (
     IN const PICT_HANDLE task,
     IN const PICT_HANDLE model
-    );
-
-// ////////////////////////////////////////////////////////////////////////////
-//
-// Sets how many worker threads the engine may use to parallelize a single
-// generation. Performance only: output is bit-for-bit identical regardless of the
-// thread count (same seed -> same test suite). Must be called before PictGenerate.
-//
-// Parameters:
-//   task         Valid handle of a task
-//   threadCount  0 = auto (hardware concurrency), 1 = serial (default), N = N threads
-//
-// Returns:
-//   Nothing
-//
-// ////////////////////////////////////////////////////////////////////////////
-
-void
-API_SPEC
-PictSetThreadCount
-    (
-    IN const PICT_HANDLE task,
-    IN       size_t      threadCount
     );
 
 // ////////////////////////////////////////////////////////////////////////////

--- a/api/task.cpp
+++ b/api/task.cpp
@@ -16,8 +16,6 @@ Task::Task() :
       m_maxRandomTries(DefaultMaxRandomTries),
       m_workbuf       (nullptr)
 {
-    Combination::ResetId();
-
 #if ( defined(_DOUT) || defined(_FILE) )
     wcerr << L"WARNING: _DOUT or _FILE are defined\n";
 #endif

--- a/api/task.cpp
+++ b/api/task.cpp
@@ -9,12 +9,13 @@ const size_t DefaultMaxRandomTries = 1000;
 //
 //
 //
-Task::Task() :
+Task::Task( size_t maxThreads ) :
       m_rootModel     (nullptr),
       m_abortCallback (nullptr),
       m_generationMode(GenerationMode::Regular),
       m_maxRandomTries(DefaultMaxRandomTries),
-      m_workbuf       (nullptr)
+            m_workbuf       (nullptr),
+            m_pool          (maxThreads)
 {
 #if ( defined(_DOUT) || defined(_FILE) )
     wcerr << L"WARNING: _DOUT or _FILE are defined\n";

--- a/api/threadpool.h
+++ b/api/threadpool.h
@@ -1,0 +1,212 @@
+#pragma once
+//
+// A small persistent worker pool used to parallelize the hot reduction loop in
+// generation (the gcd combination-selection scan). It is owned by a Task and is only
+// ever driven from that Task's single generation thread - workers never call back
+// into ParallelFor - so the public API needs no locking against concurrent
+// submission.
+//
+// Determinism note: parallelFor makes NO ordering guarantee. It only promises that
+// fn(i) is invoked exactly once for every i in [begin, end). Callers must therefore
+// write results into pre-sized, index-addressed storage and perform any ordered
+// work (selection, RNG draws) serially afterwards. This is what lets the engine be
+// both parallel and bit-for-bit reproducible.
+//
+
+#include <algorithm>
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <exception>
+#include <mutex>
+#include <thread>
+#include <type_traits>
+#include <vector>
+
+namespace pictcore
+{
+
+class ThreadPool
+{
+public:
+    ThreadPool() = default;
+    ~ThreadPool() { Stop(); }
+
+    ThreadPool( const ThreadPool& ) = delete;
+    ThreadPool& operator=( const ThreadPool& ) = delete;
+
+    // Total number of participating threads (workers + the calling thread).
+    size_t Concurrency() const { return m_workers.size() + 1; }
+
+    // Lazily create (totalThreads - 1) persistent workers. totalThreads <= 1 keeps
+    // the pool empty (everything runs on the caller). Called only from the Task's
+    // generation thread.
+    void EnsureStarted( size_t totalThreads )
+    {
+        if( !m_workers.empty() || totalThreads <= 1 )
+        {
+            return;
+        }
+
+        m_stop = false;
+        const size_t workerCount = totalThreads - 1;
+        m_workers.reserve( workerCount );
+        for( size_t i = 0; i < workerCount; ++i )
+        {
+            m_workers.emplace_back( [this]() { workerLoop(); } );
+        }
+    }
+
+    void Stop()
+    {
+        if( m_workers.empty() )
+        {
+            return;
+        }
+        {
+            std::lock_guard<std::mutex> lock( m_mutex );
+            m_stop = true;
+            ++m_round;
+        }
+        m_cvWork.notify_all();
+        for( auto& t : m_workers )
+        {
+            if( t.joinable() ) t.join();
+        }
+        m_workers.clear();
+    }
+
+    //
+    // Invoke fn(i) for every i in [begin, end). The calling thread participates.
+    // Falls back to a plain serial loop when there are no workers or the range is
+    // smaller than one grain - so tiny work never pays synchronization cost.
+    //
+    template<class Fn>
+    void ParallelFor( size_t begin, size_t end, size_t grain, Fn&& fn )
+    {
+        grain = ( grain < 1 ) ? 1 : grain;
+
+        if( m_workers.empty() || ( end - begin ) <= grain )
+        {
+            for( size_t i = begin; i < end; ++i )
+            {
+                fn( i );
+            }
+            return;
+        }
+
+        // Type-erase fn without heap allocation; fn outlives the round because this
+        // function blocks until all chunks complete.
+        using FnType = typename std::remove_reference<Fn>::type;
+        m_ctx = static_cast<void*>( &fn );
+        m_trampoline = []( void* ctx, size_t i ) { ( *static_cast<FnType*>( ctx ) )( i ); };
+
+        {
+            std::lock_guard<std::mutex> lock( m_mutex );
+            m_next.store( begin, std::memory_order_relaxed );
+            m_end          = end;
+            m_grain        = grain;
+            m_error        = nullptr;
+            m_activeWorkers = m_workers.size();
+            ++m_round;
+        }
+        m_cvWork.notify_all();
+
+        // The caller pulls chunks too.
+        runChunks();
+
+        // Wait for workers to drain this round.
+        {
+            std::unique_lock<std::mutex> lock( m_mutex );
+            m_cvDone.wait( lock, [this]() { return m_activeWorkers == 0; } );
+        }
+
+        m_ctx        = nullptr;
+        m_trampoline = nullptr;
+
+        if( m_error )
+        {
+            std::exception_ptr err = m_error;
+            m_error = nullptr;
+            std::rethrow_exception( err );
+        }
+    }
+
+private:
+    void runChunks()
+    {
+        for( ;; )
+        {
+            const size_t i = m_next.fetch_add( m_grain, std::memory_order_relaxed );
+            if( i >= m_end )
+            {
+                break;
+            }
+            const size_t j = std::min( i + m_grain, m_end );
+            try
+            {
+                for( size_t k = i; k < j; ++k )
+                {
+                    m_trampoline( m_ctx, k );
+                }
+            }
+            catch( ... )
+            {
+                std::lock_guard<std::mutex> lock( m_mutex );
+                if( !m_error )
+                {
+                    m_error = std::current_exception();
+                }
+                // Stop everyone from grabbing more work this round.
+                m_next.store( m_end, std::memory_order_relaxed );
+                break;
+            }
+        }
+    }
+
+    void workerLoop()
+    {
+        size_t lastRound = 0;
+        for( ;; )
+        {
+            {
+                std::unique_lock<std::mutex> lock( m_mutex );
+                m_cvWork.wait( lock, [this, lastRound]() { return m_stop || m_round != lastRound; } );
+                if( m_stop )
+                {
+                    return;
+                }
+                lastRound = m_round;
+            }
+
+            runChunks();
+
+            {
+                std::lock_guard<std::mutex> lock( m_mutex );
+                if( --m_activeWorkers == 0 )
+                {
+                    m_cvDone.notify_one();
+                }
+            }
+        }
+    }
+
+    std::vector<std::thread> m_workers;
+    std::mutex               m_mutex;
+    std::condition_variable  m_cvWork;
+    std::condition_variable  m_cvDone;
+
+    // Current job (set under lock before notify, read after the lock handshake).
+    void  ( *m_trampoline )( void*, size_t ) = nullptr;
+    void*               m_ctx     = nullptr;
+    std::atomic<size_t> m_next{ 0 };
+    size_t              m_end   = 0;
+    size_t              m_grain = 1;
+
+    size_t             m_round         = 0;
+    size_t             m_activeWorkers = 0;
+    bool               m_stop          = false;
+    std::exception_ptr m_error;
+};
+
+}

--- a/api/threadpool.h
+++ b/api/threadpool.h
@@ -29,33 +29,12 @@ namespace pictcore
 class ThreadPool
 {
 public:
-    ThreadPool() = default;
+    explicit ThreadPool( size_t totalThreads = 1 ) :
+        m_totalThreads( ( totalThreads < 1 ) ? 1 : totalThreads ) {}
     ~ThreadPool() { Stop(); }
 
     ThreadPool( const ThreadPool& ) = delete;
     ThreadPool& operator=( const ThreadPool& ) = delete;
-
-    // Total number of participating threads (workers + the calling thread).
-    size_t Concurrency() const { return m_workers.size() + 1; }
-
-    // Lazily create (totalThreads - 1) persistent workers. totalThreads <= 1 keeps
-    // the pool empty (everything runs on the caller). Called only from the Task's
-    // generation thread.
-    void EnsureStarted( size_t totalThreads )
-    {
-        if( !m_workers.empty() || totalThreads <= 1 )
-        {
-            return;
-        }
-
-        m_stop = false;
-        const size_t workerCount = totalThreads - 1;
-        m_workers.reserve( workerCount );
-        for( size_t i = 0; i < workerCount; ++i )
-        {
-            m_workers.emplace_back( [this]() { workerLoop(); } );
-        }
-    }
 
     void Stop()
     {
@@ -85,6 +64,7 @@ public:
     void ParallelFor( size_t begin, size_t end, size_t grain, Fn&& fn )
     {
         grain = ( grain < 1 ) ? 1 : grain;
+        ensureStarted();
 
         if( m_workers.empty() || ( end - begin ) <= grain )
         {
@@ -133,6 +113,24 @@ public:
     }
 
 private:
+    // Lazily create the configured number of persistent workers. Called only from
+    // the owning Task's generation thread.
+    void ensureStarted()
+    {
+        if( !m_workers.empty() || m_totalThreads <= 1 )
+        {
+            return;
+        }
+
+        m_stop = false;
+        const size_t workerCount = m_totalThreads - 1;
+        m_workers.reserve( workerCount );
+        for( size_t i = 0; i < workerCount; ++i )
+        {
+            m_workers.emplace_back( [this]() { workerLoop(); } );
+        }
+    }
+
     void runChunks()
     {
         for( ;; )
@@ -191,6 +189,7 @@ private:
         }
     }
 
+    const size_t             m_totalThreads;
     std::vector<std::thread> m_workers;
     std::mutex               m_mutex;
     std::condition_variable  m_cvWork;

--- a/api/trie.h
+++ b/api/trie.h
@@ -113,8 +113,69 @@ public:
         return( pfind_prefix( t ) != nullptr );
     }
 
+    //
+    // Returns true if the trie contains at least one stored key whose elements
+    // form a subset of t. Both the stored keys and t are sorted with the same
+    // ordering (operator< on Col::value_type), so a stored key is a subset of t
+    // exactly when it is a subsequence of t. This is the polynomial-time
+    // equivalent of asking "is any stored key a prefix of some permutation of t"
+    // without enumerating t's permutations.
+    //
+    // Empty-key semantics deliberately match the prior find_prefix()+permutation
+    // approach: an empty stored key is reported only when t itself is empty (the
+    // old code never tested the root for a non-empty query), so behavior stays
+    // bit-for-bit identical.
+    //
+    bool find_subset( Col &t )
+    {
+        if( t.begin() == t.end() ) return( m_root->valid );
+        return psubset( m_root, t.begin(), t.end(), false );
+    }
+
 private:
     trienode<typename Col::value_type>* m_root;
+
+    //
+    // Recursive subset search. A stored key is found when we reach a valid node
+    // by matching a subsequence of [qbegin, qend). checkValid is false only for
+    // the initial (root) call with a non-empty query, so the empty key is not
+    // treated as a match there - preserving the original find_prefix semantics.
+    // Children are visited in ascending key order (std::map) and the query is
+    // sorted ascending, so once a child's label exceeds every remaining query
+    // element we can stop.
+    //
+    bool psubset( trienode<typename Col::value_type>* node,
+                  typename Col::iterator qbegin,
+                  typename Col::iterator qend,
+                  bool checkValid )
+    {
+        if( checkValid && node->valid ) return( true );
+
+        for( typename TNodeCol::iterator ci = node->children.begin();
+             ci != node->children.end(); ++ci )
+        {
+            const typename Col::value_type& label = ci->first;
+
+            // find label at or after qbegin (both query and children ascending)
+            typename Col::iterator q = qbegin;
+            while( q != qend && *q < label ) ++q;
+
+            // label is larger than every remaining query element: no later
+            // (even larger) child can match either
+            if( q == qend ) break;
+
+            // *q is equivalent to label -> descend, consuming this query element
+            if( !( label < *q ) )
+            {
+                typename Col::iterator next = q;
+                ++next;
+                if( psubset( ci->second, next, qend, true ) ) return( true );
+            }
+        }
+
+        return( false );
+    }
+
 
     //
     //

--- a/benchmark/pict_benchmark.cpp
+++ b/benchmark/pict_benchmark.cpp
@@ -4,16 +4,20 @@
 #endif
 
 #include <algorithm>
+#include <atomic>
 #include <cctype>
 #include <cstdint>
 #include <cstdlib>
 #include <ctime>
+#include <exception>
 #include <iomanip>
 #include <iostream>
 #include <limits>
+#include <mutex>
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "pictapi.h"
@@ -163,6 +167,69 @@ bool TryParseUnsigned( const string& text, size_t& value )
     return true;
 }
 
+//
+// Reads an unsigned, non-zero value from an environment variable.
+// Uses _dupenv_s on MSVC to avoid the deprecated-getenv warning under /WX.
+//
+bool TryGetEnvUnsigned( const char* name, size_t& value )
+{
+    string text;
+#if defined( _MSC_VER )
+    char* buffer = nullptr;
+    size_t length = 0;
+    if( _dupenv_s( &buffer, &length, name ) != 0 || buffer == nullptr )
+    {
+        if( buffer != nullptr )
+        {
+            free( buffer );
+        }
+        return false;
+    }
+    text.assign( buffer );
+    free( buffer );
+#else
+    const char* raw = getenv( name );
+    if( raw == nullptr )
+    {
+        return false;
+    }
+    text.assign( raw );
+#endif
+
+    // tolerate surrounding whitespace
+    const string::size_type first = text.find_first_not_of( " \t\r\n" );
+    if( first == string::npos )
+    {
+        return false;
+    }
+    const string::size_type last = text.find_last_not_of( " \t\r\n" );
+    text = text.substr( first, last - first + 1 );
+
+    return TryParseUnsigned( text, value ) && value != 0;
+}
+
+//
+// Resolves the worker thread count using the precedence:
+//   explicit --threads flag  >  PICT_BENCHMARK_THREADS env var  >  hardware_concurrency()
+// commandLineThreads == 0 means the flag was not supplied.
+//
+size_t ResolveThreadCount( size_t commandLineThreads )
+{
+    if( commandLineThreads != 0 )
+    {
+        return commandLineThreads;
+    }
+
+    size_t envThreads = 0;
+    if( TryGetEnvUnsigned( "PICT_BENCHMARK_THREADS", envThreads ) )
+    {
+        return envThreads;
+    }
+
+    const unsigned int detected = thread::hardware_concurrency();
+    return ( detected == 0 ) ? size_t( 1 ) : static_cast<size_t>( detected );
+}
+
 bool TryParseBenchmarkSpec( const string& spec, BenchmarkDefinition& benchmark )
 {
     string rewritten = spec;
@@ -294,7 +361,7 @@ size_t RunSingleTrial( const BenchmarkDefinition& benchmark, unsigned int seed )
     return resultCount;
 }
 
-BenchmarkResult RunBenchmark( const BenchmarkDefinition& benchmark, size_t runs, unsigned int& seedState )
+BenchmarkResult RunBenchmark( const BenchmarkDefinition& benchmark, size_t runs, unsigned int& seedState, size_t threadCount )
 {
     BenchmarkResult result;
     result.Name = benchmark.Name;
@@ -304,22 +371,95 @@ BenchmarkResult RunBenchmark( const BenchmarkDefinition& benchmark, size_t runs,
     result.BestKnownRows = benchmark.BestKnownRows;
     result.PictReferenceRows = benchmark.PictReferenceRows;
 
+    // Pre-compute every trial seed in order so the exact LCG sequence (and thus
+    // the chosen seeds) is identical regardless of how trials are scheduled.
+    vector<unsigned int> seeds( runs );
     for( size_t run = 0; run < runs; ++run )
     {
         seedState = seedState * 1664525u + 1013904223u;
-        const unsigned int trialSeed = seedState;
-        const size_t rows = RunSingleTrial( benchmark, trialSeed );
+        seeds[ run ] = seedState;
+    }
+
+    // Each trial is fully independent (its own PICT task/model/RNG), so trials can
+    // run concurrently. Results are stored by index and reduced in index order,
+    // which reproduces the serial "first trial with the smallest suite" selection.
+    vector<size_t> trialRows( runs, 0 );
+    exception_ptr firstError = nullptr;
+    mutex errorMutex;
+
+    auto runRange = [&]( size_t first, size_t last )
+    {
+        for( size_t run = first; run < last; ++run )
+        {
+            try
+            {
+                trialRows[ run ] = RunSingleTrial( benchmark, seeds[ run ] );
+            }
+            catch( ... )
+            {
+                lock_guard<mutex> guard( errorMutex );
+                if( firstError == nullptr )
+                {
+                    firstError = current_exception();
+                }
+                trialRows[ run ] = numeric_limits<size_t>::max();
+            }
+        }
+    };
+
+    const size_t workers = ( threadCount <= 1 ) ? 1 : min( threadCount, runs == 0 ? size_t( 1 ) : runs );
+    if( workers <= 1 )
+    {
+        runRange( 0, runs );
+    }
+    else
+    {
+        atomic<size_t> nextIndex( 0 );
+        auto worker = [&]()
+        {
+            for( ;; )
+            {
+                const size_t run = nextIndex.fetch_add( 1 );
+                if( run >= runs )
+                {
+                    break;
+                }
+                runRange( run, run + 1 );
+            }
+        };
+
+        vector<thread> pool;
+        pool.reserve( workers );
+        for( size_t t = 0; t < workers; ++t )
+        {
+            pool.emplace_back( worker );
+        }
+        for( size_t t = 0; t < pool.size(); ++t )
+        {
+            pool[ t ].join();
+        }
+    }
+
+    if( firstError != nullptr )
+    {
+        rethrow_exception( firstError );
+    }
+
+    // Deterministic reduction and logging, in trial order.
+    for( size_t run = 0; run < runs; ++run )
+    {
+        const size_t rows = trialRows[ run ];
 
         cerr << "[trial " << ( run + 1 ) << "/" << runs << "] "
              << "benchmark=\"" << benchmark.Name << "\" "
              << "model=\"" << FormatModelShape( benchmark ) << "\" "
-             << "seed=" << trialSeed << ' '
+             << "seed=" << seeds[ run ] << ' '
              << "rows=" << rows << endl;
 
         if( rows < result.BestRows )
         {
             result.BestRows = rows;
-            result.BestSeed = trialSeed;
+            result.BestSeed = seeds[ run ];
         }
     }
 
@@ -340,14 +480,20 @@ string ToText( int value )
 
 void PrintUsage( const char* programName )
 {
-    cerr << "Usage: " << programName << " [--runs N] [--seed N] [--benchmark SPEC]..." << endl;
+    cerr << "Usage: " << programName << " [--runs N] [--seed N] [--threads N] [--benchmark SPEC]..." << endl;
     cerr << "       " << programName << " --list" << endl;
     cerr << endl;
     cerr << "Runs the standard pairwise benchmark scenarios repeatedly with different seeds" << endl;
     cerr << "and reports the smallest generated suite for each selected benchmark." << endl;
     cerr << endl;
+    cerr << "  --threads N  run independent trials across N worker threads." << endl;
+    cerr << "               Precedence: --threads > PICT_BENCHMARK_THREADS env var >" << endl;
+    cerr << "               hardware_concurrency() default. Best-suite selection is" << endl;
+    cerr << "               deterministic regardless of N." << endl;
+    cerr << endl;
     cerr << "Examples:" << endl;
     cerr << "  " << programName << " --runs 1000" << endl;
+    cerr << "  " << programName << " --runs 1000 --threads 8" << endl;
     cerr << "  " << programName << " --runs 250 --benchmark 3^13 --benchmark \"4^15 3^17 2^29\"" << endl;
     cerr << "  " << programName << " --runs 500 --benchmark \"6^20\"" << endl;
 }
@@ -414,6 +560,7 @@ int __cdecl main( int argc, char* argv[] )
     {
         size_t runs = 1000;
         unsigned int baseSeed = static_cast<unsigned int>( time( nullptr ));
+        size_t threadCount = 0; // 0 == not set on the command line
         vector<BenchmarkDefinition> selectedBenchmarks;
 
         for( int index = 1; index < argc; ++index )
@@ -438,6 +585,18 @@ int __cdecl main( int argc, char* argv[] )
                 {
                     throw runtime_error( "Expected a positive integer after --runs" );
                 }
+                continue;
+            }
+
+            if( argument == "--threads" || argument == "-t" )
+            {
+                size_t parsedThreads = 0;
+                if( index + 1 >= argc || !TryParseUnsigned( argv[ ++index ], parsedThreads ) || parsedThreads == 0 )
+                {
+                    throw runtime_error( "Expected a positive integer after --threads" );
+                }
+
+                threadCount = parsedThreads;
                 continue;
             }
 
@@ -482,9 +641,11 @@ int __cdecl main( int argc, char* argv[] )
         results.reserve( selectedBenchmarks.size() );
 
         unsigned int seedState = baseSeed;
+        const size_t resolvedThreads = ResolveThreadCount( threadCount );
+        cerr << "Worker threads: " << resolvedThreads << endl;
         for( size_t index = 0; index < selectedBenchmarks.size(); ++index )
         {
-            results.push_back( RunBenchmark( selectedBenchmarks[ index ], runs, seedState ));
+            results.push_back( RunBenchmark( selectedBenchmarks[ index ], runs, seedState, resolvedThreads ));
         }
 
         PrintResults( results, runs, baseSeed );

--- a/cli/cmdline.cpp
+++ b/cli/cmdline.cpp
@@ -284,6 +284,30 @@ bool parseArg( wchar_t* text, CModelData& modelData )
         }
         break;
     }
+    case SWITCH_BEST:
+    {
+        // /b:N - run N independent generations and keep the smallest suite
+        unsigned int i = getUIntFromArg( text );
+        if( i == 0 )
+        {
+            unknownOption = true;
+            break;
+        }
+        modelData.BestOf = i;
+        break;
+    }
+    case SWITCH_THREADS:
+    {
+        // /t:N - number of worker threads for generation (and best-of-N trials)
+        unsigned int i = getUIntFromArg( text );
+        if( i == 0 )
+        {
+            unknownOption = true;
+            break;
+        }
+        modelData.ThreadCount = i;
+        break;
+    }
     default:
     {
         unknownOption = true;
@@ -318,6 +342,8 @@ void showUsage()
     wcout << L" /" << charToStr( SWITCH_NEGATIVE_VALUES )   << L":C             - Negative value prefix (default: ~)" << endl;
     wcout << L" /" << charToStr( SWITCH_SEED_FILE )         << L":file          - File with seeding rows"             << endl;
     wcout << L" /" << charToStr( SWITCH_RANDOMIZE )         << L"[:N]           - Randomize generation, N - seed"     << endl;
+    wcout << L" /" << charToStr( SWITCH_BEST )              << L":N             - Try N seeds, keep the smallest suite" << endl;
+    wcout << L" /" << charToStr( SWITCH_THREADS )           << L":N             - Number of worker threads (default: auto)" << endl;
     wcout << L" /" << charToStr( SWITCH_FORMAT )            << L"[:text|json]   - Output format (default: text)"      << endl;
     wcout << L" /" << charToStr( SWITCH_CASE_SENSITIVE )    << L"               - Case-sensitive model evaluation"    << endl;
     wcout << L" /" << charToStr( SWITCH_STATISTICS )        << L"               - Show model statistics"              << endl;

--- a/cli/cmdline.h
+++ b/cli/cmdline.h
@@ -22,6 +22,8 @@ const wchar_t SWITCH_VERBOSE         = L'v';
 const wchar_t SWITCH_PREVIEW         = L'p';
 const wchar_t SWITCH_APPROXIMATE     = L'x';
 const wchar_t SWITCH_FORMAT          = L'f';
+const wchar_t SWITCH_BEST            = L'b';
+const wchar_t SWITCH_THREADS         = L't';
 
 //
 //

--- a/cli/gcd.cpp
+++ b/cli/gcd.cpp
@@ -35,7 +35,6 @@ ErrorCode GcdRunner::generateResults( IN CModelData& modelData, IN bool justNega
     Model* model = gcdData.GetRootModel();
     model->SetRandomSeed( modelData.RandSeed );
     model->GetTask()->SeedRandom( static_cast<unsigned int>( modelData.RandSeed ) );
-    model->GetTask()->SetMaxThreads( modelData.EngineThreads );
     try
     {
         for( auto & submodel : model->GetSubmodels() )

--- a/cli/gcd.cpp
+++ b/cli/gcd.cpp
@@ -34,6 +34,8 @@ ErrorCode GcdRunner::generateResults( IN CModelData& modelData, IN bool justNega
     // run the generation from bottom up
     Model* model = gcdData.GetRootModel();
     model->SetRandomSeed( modelData.RandSeed );
+    model->GetTask()->SeedRandom( static_cast<unsigned int>( modelData.RandSeed ) );
+    model->GetTask()->SetMaxThreads( modelData.EngineThreads );
     try
     {
         for( auto & submodel : model->GetSubmodels() )

--- a/cli/gcdmodel.h
+++ b/cli/gcdmodel.h
@@ -66,7 +66,7 @@ public:
     std::vector< Parameter* > Parameters;
     CGcdExclusions            Exclusions;
 
-    CGcdData( CModelData& modelData ) : _modelData( modelData ) {}
+    CGcdData( CModelData& modelData ) : _modelData( modelData ), _task( modelData.EngineThreads ) {}
 
     ~CGcdData()
     {

--- a/cli/model.h
+++ b/cli/model.h
@@ -99,6 +99,9 @@ public:
     wchar_t                   NamesDelim;
     wchar_t                   InvalidPrefix;
     unsigned short            RandSeed;
+    size_t                    BestOf;          // /b:N - try N seeds, keep the smallest suite (1 = disabled)
+    size_t                    ThreadCount;     // /t:N - worker threads (0 = auto); applies to /b trials or engine
+    size_t                    EngineThreads;   // resolved worker count for a single in-engine generation (1 = serial)
     bool                      CaseSensitive;
     bool                      Verbose;         // prints out some additional info while generating
     bool                      Statistics;      // show the statistics only
@@ -121,6 +124,9 @@ public:
         NamesDelim(L'|'),
         InvalidPrefix(L'~'),
         RandSeed(0),
+        BestOf(1),
+        ThreadCount(0),
+        EngineThreads(1),
         CaseSensitive(false),
         Verbose(false),
         Statistics(false),

--- a/cli/pict.cpp
+++ b/cli/pict.cpp
@@ -3,17 +3,157 @@
 #define __cdecl
 #endif
 
+#include <atomic>
+#include <cstdlib>
 #include <ctime>
 #include <cstring>
 #include <iostream>
+#include <limits>
 #include <locale>
+#include <mutex>
 #include <stdexcept>
+#include <thread>
+#include <vector>
 using namespace std;
 
 #include "cmdline.h"
 #include "gcd.h"
 #include "strings.h"
 using namespace pictcli_gcd;
+
+//
+// Resolves the worker thread count for best-of-N search.
+// Precedence: explicit /t:N (requested != 0) > PICT_THREADS env var > hardware_concurrency().
+//
+static size_t resolveThreadCount( size_t requested )
+{
+    if( requested != 0 )
+    {
+        return requested;
+    }
+
+    size_t envThreads = 0;
+#if defined( _MSC_VER )
+    char*  buffer = nullptr;
+    size_t length = 0;
+    if( _dupenv_s( &buffer, &length, "PICT_THREADS" ) == 0 && buffer != nullptr )
+    {
+        envThreads = static_cast<size_t>( strtoul( buffer, nullptr, 10 ) );
+    }
+    if( buffer != nullptr )
+    {
+        free( buffer );
+    }
+#else
+    const char* raw = getenv( "PICT_THREADS" );
+    if( raw != nullptr )
+    {
+        envThreads = static_cast<size_t>( strtoul( raw, nullptr, 10 ) );
+    }
+#endif
+    if( envThreads != 0 )
+    {
+        return envThreads;
+    }
+
+    const unsigned int detected = thread::hardware_concurrency();
+    return ( detected == 0 ) ? static_cast<size_t>( 1 ) : static_cast<size_t>( detected );
+}
+
+//
+// Runs one full generation for a single seed and returns the resulting suite size.
+// Returns SIZE_MAX if generation fails (e.g. a seed-dependent generation failure),
+// so that successful seeds are always preferred during reduction.
+//
+static size_t trialSuiteSize( const CModelData& baseModelData, unsigned short seed )
+{
+    CModelData modelData = baseModelData; // deep copy; GcdPointers are null pre-generation
+    modelData.RandSeed      = seed;
+    modelData.Verbose       = false;      // keep per-trial runs quiet and deterministic
+    modelData.EngineThreads = 1;          // trials parallelize across seeds, not inside the engine
+
+    GcdRunner runner( modelData );
+    if( runner.Generate() != ErrorCode::ErrorCode_Success )
+    {
+        return numeric_limits<size_t>::max();
+    }
+    return runner.GetResult().TestCases.size();
+}
+
+//
+// Best-of-N seed search.
+// Tries 'bestOf' independent seeds derived deterministically from the base seed and
+// returns the seed that produced the smallest suite. Ties are broken by the earliest
+// seed in the sequence, so the winner is independent of how trials are scheduled.
+// Each trial is a fully independent generation (own model copy, task, and RNG), which
+// is what makes parallel execution safe and bit-for-bit reproducible.
+//
+static unsigned short findBestSeed
+    (
+    IN  const CModelData& modelData,
+    IN  size_t            bestOf,
+    IN  size_t            threadCount,
+    OUT size_t&           bestRows
+    )
+{
+    const unsigned short baseSeed = modelData.RandSeed;
+
+    // Pre-compute every trial seed up front so the sequence (and thus the chosen
+    // winner) is identical regardless of thread scheduling.
+    vector<unsigned short> seeds( bestOf );
+    for( size_t i = 0; i < bestOf; ++i )
+    {
+        seeds[ i ] = static_cast<unsigned short>( baseSeed + i );
+    }
+
+    vector<size_t> rows( bestOf, numeric_limits<size_t>::max() );
+
+    const size_t workers = ( threadCount <= 1 ) ? 1 : min( threadCount, bestOf );
+    if( workers <= 1 )
+    {
+        for( size_t i = 0; i < bestOf; ++i )
+        {
+            rows[ i ] = trialSuiteSize( modelData, seeds[ i ] );
+        }
+    }
+    else
+    {
+        atomic<size_t> nextIndex( 0 );
+        auto worker = [&]()
+        {
+            for( ;; )
+            {
+                const size_t i = nextIndex.fetch_add( 1 );
+                if( i >= bestOf ) break;
+                rows[ i ] = trialSuiteSize( modelData, seeds[ i ] );
+            }
+        };
+
+        vector<thread> pool;
+        pool.reserve( workers );
+        for( size_t t = 0; t < workers; ++t )
+        {
+            pool.emplace_back( worker );
+        }
+        for( size_t t = 0; t < pool.size(); ++t )
+        {
+            pool[ t ].join();
+        }
+    }
+
+    // Deterministic reduction: smallest suite wins, ties broken by earliest seed.
+    size_t bestIndex = 0;
+    for( size_t i = 1; i < bestOf; ++i )
+    {
+        if( rows[ i ] < rows[ bestIndex ] )
+        {
+            bestIndex = i;
+        }
+    }
+
+    bestRows = rows[ bestIndex ];
+    return seeds[ bestIndex ];
+}
 
 //
 //
@@ -66,6 +206,40 @@ int __cdecl execute
     {
         return( (int)ErrorCode::ErrorCode_BadRowSeedFile );
     }
+
+    // Resolve worker threads once. When best-of-N is active, the threads parallelize
+    // independent seed trials (engine stays serial per trial); otherwise they
+    // parallelize inside the single generation.
+    const size_t resolvedThreads = resolveThreadCount( modelData.ThreadCount );
+
+    // Best-of-N: try several seeds and keep the smallest suite. The search runs
+    // independent generations (optionally in parallel); the winning seed is then
+    // used for the single authoritative generation below, so output, statistics,
+    // verbose, and JSON formatting all follow the exact same path as a normal run.
+    if( modelData.BestOf > 1 )
+    {
+        size_t bestRows = 0;
+        unsigned short bestSeed = findBestSeed( modelData,
+                                                modelData.BestOf,
+                                                resolvedThreads,
+                                                bestRows );
+        modelData.RandSeed = bestSeed;
+
+        wcerr << L"Best of " << modelData.BestOf << L" seeds: seed "
+              << static_cast<int>( bestSeed ) << L" produced ";
+        if( bestRows == numeric_limits<size_t>::max() )
+        {
+            wcerr << L"no result";
+        }
+        else
+        {
+            wcerr << bestRows << L" rows";
+        }
+        wcerr << endl;
+    }
+
+    // The single authoritative generation may use the engine worker pool.
+    modelData.EngineThreads = resolvedThreads;
 
     GcdRunner gcdRunner( modelData );
 

--- a/doc/pict.md
+++ b/doc/pict.md
@@ -32,8 +32,29 @@ PICT is a command-line tool that accepts a plain-text model file as an input and
       /n:C     - Negative value prefix (default: ~)
       /e:file  - File with seeding rows
       /r[:N]   - Randomize generation, N - seed
+      /b:N     - Try N seeds, keep the smallest suite
+      /t:N     - Number of worker threads (default: auto)
       /c       - Case-sensitive model evaluation
       /s       - Show model statistics
+
+### Best-of-N generation
+
+The size of a generated suite depends on the random seed (see `/r`). The `/b:N` option
+runs generation for `N` different seeds and keeps the smallest resulting suite. The seeds
+are derived deterministically from the base seed, so the result is reproducible: the same
+`/b:N` (and `/r:N`, if given) always selects the same winning seed and produces the same
+suite.
+
+### Parallelism
+
+PICT can use multiple worker threads to speed up generation. `/t:N` sets the number of
+threads; the default (`auto`) uses all available logical processors, and `/t:1` forces
+single-threaded generation. When combined with `/b`, the threads also run the independent
+seed trials concurrently.
+
+Parallelism is purely a performance option: it never changes the produced test suite. For
+a given seed, PICT generates the exact same, bit-for-bit identical set of test cases
+regardless of the thread count.
 
 ## Model File 
 


### PR DESCRIPTION

## Performance: parallel generation and faster constraint derivation

Two separate performance changes, both opt-in and both bit-exact — a given seed still
produces the exact same test suite it did before, no matter the thread count or which
change is in play.

### Parallel generation

The combination-selection scan in `Model::gcd` can now run on multiple threads through a
per-`Task` thread pool. To keep output deterministic, the per-combination work runs in
parallel but selection and all RNG draws still happen serially in the original order. That
required moving the RNG and the combination-ID counter off of global state and onto the
`Task`; the RNG matches the MSVC CRT LCG, so the numbers it produces don't change.

- `/t:N` on the CLI picks the thread count (defaults to all cores; `/t:1` is serial).
  Small models stay serial, so there's no overhead where threading wouldn't help.
- `PictSetThreadCount(task, n)` does the same from the API (0 = auto, 1 = serial default).

On a 26-parameter, 10-value, 3-way model this runs about 3.4x faster on 12 threads, with
identical output. Scaling is sub-linear because the selection/commit phase stays serial.

### Faster constraint derivation

Heavily-constrained models spend most of their time in constraint *derivation*, before
generation even starts. The redundancy check in `ExclusionDeriver::alreadyInCollection`
used to walk every permutation of an exclusion — O(k!), so a single k=13 check was on the
order of 6 billion trie lookups. That's replaced with a subset search over the trie
(`trie::find_subset`), which is polynomial and returns the same answer.

This removes the factorial blow-up. On a 35-parameter model from a report about generation
taking far too long, this brought a run down from ~99 min to ~55 min, and models with large
derived exclusions no longer fall off a cliff.

### Other changes

- `/b:N`: generate with N seeds and keep the smallest suite (deterministic; runs the trials
  in parallel).
- `doc/pict.md` documents `/t` and `/b`; the API sample shows `PictSetThreadCount`.
- NuGet package version 3.8.0 -> 3.9.0 (minor: additive, output unchanged).

### Combined effect

On a model built to hit both paths (~31 min without either change):

| Configuration       | Time      | Speedup |
| ------------------- | --------- | ------- |
| Original            | 31.0 min  | 1.00x   |
| Parallelism only    | 25.3 min  | 1.23x   |
| Constraint fix only | 13.7 min  | 2.26x   |
| Both                | 8.0 min   | 3.88x   |

### Correctness

Output was checked byte-for-byte across all four configurations above. The full test suite
passes (including its seeding-reproducibility re-runs), 224 constrained/functional/real
models match between the old and new code paths, and parallel output matches serial.